### PR TITLE
v1.3.0 — Focus timers, recurring tasks, settings & startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,75 @@
 name: Release
 
+# Publishes a release when a version bump lands on main. The version is read
+# from package.json; a release is cut only when no release exists for it yet,
+# so ordinary pushes (or re-runs) never republish. Release notes are pulled
+# from the matching section of CHANGELOG.md.
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'src-tauri/tauri.conf.json'
+      - 'src-tauri/Cargo.toml'
   workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  check:
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      release: ${{ steps.detect.outputs.release }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect version and whether it needs releasing
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists — nothing to do."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "v$VERSION is new — will build and publish."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
   release:
+    needs: check
+    if: needs.check.outputs.release == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${{ needs.check.outputs.version }}"
+          NOTES=$(awk -v v="## v$VERSION" '
+            index($0, v) == 1 { grab = 1; next }
+            /^## v/ && grab { exit }
+            grab { print }
+          ' CHANGELOG.md)
+          if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
+            NOTES="Download a bundle below (.deb, .rpm, or .AppImage)."
+          fi
+          {
+            echo 'RELEASE_NOTES<<CHANGELOG_EOF'
+            printf '%s\n' "$NOTES"
+            echo ''
+            echo '---'
+            echo 'Download a bundle below (.deb, .rpm, or .AppImage).'
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_ENV"
 
       - name: Install system dependencies
         run: |
@@ -38,8 +94,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'todofy ${{ github.ref_name }}'
-          releaseBody: 'Download a bundle below (.deb, .rpm, or .AppImage). See CHANGELOG.md for release notes.'
+          tagName: v${{ needs.check.outputs.version }}
+          releaseName: 'todofy v${{ needs.check.outputs.version }}'
+          releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v1.3.0 — 2026-08-16
+
+### Added
+- Focus timers — two independent, backend-tracked timers that keep counting while todofy is hidden in the tray and survive a restart:
+  - Pomodoro (focus / short break / long break) with Start·Pause, Reset, and Skip, plus configurable phase lengths
+  - Per-task stopwatch — press play on any task to track time on it; each session is recorded and the task shows its total focused time
+  - Neither timer auto-stops: when a phase finishes or a stopwatch runs long, todofy sends a notification and keeps counting
+- Focus screen — a dedicated page to start the Pomodoro, tune its lengths, and browse focus history (Today / This week / Tracked-total, grouped by day); opens from the floating focus widget
+- Focus widget — a floating timer panel (bottom-left) with live countdowns, opened from the sidebar
+- Tray timer controls — start/pause the Pomodoro and stop the task stopwatch from the tray menu, with a live status line and a countdown shown on the tray icon
+- Recurring tasks — set a task to repeat Daily, Every weekday, Weekly, Monthly, or Yearly; completing it rolls the due date and reminder to the next occurrence instead of finishing it. Also parsed from natural language ("water plants every week")
+- Settings screen — with run-on-startup (launch todofy at login, opening the window or starting quietly in the tray)
+
+### Changed
+- Pomodoro length settings live on the Focus screen (not the Settings screen)
+- Theme toggle moved from the sidebar into Settings → Appearance
+- The main window now starts hidden and is revealed by the backend, so a tray-mode login launch no longer flashes a window
+- Content Security Policy is now enabled (previously disabled)
+
+### Fixed
+- Clearing a task's date, reminder, or notes is no longer a silent no-op — a serde `Option<Option<T>>` quirk had been collapsing an explicit `null` into "leave unchanged"
+
 ## v1.2.0 — 2026-08-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todofy",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -220,6 +220,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,11 +759,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -763,7 +794,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -890,7 +921,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.4+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2859,6 +2890,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3540,7 +3582,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3590,7 +3632,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3658,6 +3700,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3962,7 +4018,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todofy"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3970,6 +4026,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -4206,7 +4263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5039,6 +5096,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5069,7 +5135,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "todofy"
-version = "1.2.0"
+version = "1.3.0"
 description = "A modern to-do app for Linux"
-authors = ["you"]
+authors = ["Salar Zeidanlou"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,9 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "notification:default"
+    "notification:default",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::db::Db;
 use crate::models::{Label, NewTask, Task, TaskPatch};
+use crate::recur;
 use chrono::Local;
 use rusqlite::{params, Connection};
 use tauri::State;
@@ -21,7 +22,9 @@ fn label_ids_for(conn: &Connection, task_id: i64) -> rusqlite::Result<Vec<i64>> 
 fn load_task(conn: &Connection, id: i64) -> rusqlite::Result<Task> {
     let mut task = conn.query_row(
         "SELECT id, title, notes, due_date, remind_at, status, priority,
-                created_at, completed_at, order_index, pinned
+                created_at, completed_at, order_index, pinned, repeat,
+                (SELECT COALESCE(SUM(seconds), 0) FROM time_sessions
+                 WHERE task_id = tasks.id AND end_at IS NOT NULL)
          FROM tasks WHERE id = ?1",
         [id],
         |r| {
@@ -37,6 +40,8 @@ fn load_task(conn: &Connection, id: i64) -> rusqlite::Result<Task> {
                 completed_at: r.get(8)?,
                 order_index: r.get(9)?,
                 pinned: r.get(10)?,
+                repeat: r.get(11)?,
+                tracked_seconds: r.get(12)?,
                 label_ids: Vec::new(),
             })
         },
@@ -58,7 +63,7 @@ fn set_labels(conn: &Connection, task_id: i64, label_ids: &[i64]) -> rusqlite::R
 
 #[tauri::command]
 pub fn list_tasks(db: State<Db>) -> CmdResult<Vec<Task>> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     // Manual order (order_index) is the primary sort so drag-to-reorder
     // sticks; priority is a visual tag, not a sort key. Done tasks sink.
     let mut stmt = conn
@@ -79,11 +84,11 @@ pub fn list_tasks(db: State<Db>) -> CmdResult<Vec<Task>> {
 
 #[tauri::command]
 pub fn create_task(db: State<Db>, task: NewTask) -> CmdResult<Task> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     let created = now_iso();
     conn.execute(
-        "INSERT INTO tasks (title, notes, due_date, remind_at, priority, created_at, order_index)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO tasks (title, notes, due_date, remind_at, priority, created_at, order_index, repeat)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             task.title.trim(),
             task.notes,
@@ -92,6 +97,7 @@ pub fn create_task(db: State<Db>, task: NewTask) -> CmdResult<Task> {
             task.priority.unwrap_or(4),
             created,
             Local::now().timestamp_millis() as f64,
+            task.repeat,
         ],
     )
     .map_err(|e| e.to_string())?;
@@ -104,7 +110,7 @@ pub fn create_task(db: State<Db>, task: NewTask) -> CmdResult<Task> {
 
 #[tauri::command]
 pub fn update_task(db: State<Db>, patch: TaskPatch) -> CmdResult<Task> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     if let Some(title) = &patch.title {
         conn.execute(
             "UPDATE tasks SET title = ?1 WHERE id = ?2",
@@ -151,6 +157,14 @@ pub fn update_task(db: State<Db>, patch: TaskPatch) -> CmdResult<Task> {
         )
         .map_err(|e| e.to_string())?;
     }
+    if let Some(repeat) = &patch.repeat {
+        // `Some(None)` clears the recurrence; `Some(Some(rule))` sets it.
+        conn.execute(
+            "UPDATE tasks SET repeat = ?1 WHERE id = ?2",
+            params![repeat, patch.id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
     load_task(&conn, patch.id).map_err(|e| e.to_string())
 }
 
@@ -159,7 +173,7 @@ pub fn update_task(db: State<Db>, patch: TaskPatch) -> CmdResult<Task> {
 /// so reordering never has to renumber the whole list.
 #[tauri::command]
 pub fn reorder_task(db: State<Db>, id: i64, order_index: f64) -> CmdResult<Task> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     conn.execute(
         "UPDATE tasks SET order_index = ?1 WHERE id = ?2",
         params![order_index, id],
@@ -170,7 +184,36 @@ pub fn reorder_task(db: State<Db>, id: i64, order_index: f64) -> CmdResult<Task>
 
 #[tauri::command]
 pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
+    // Completing a repeating task rolls it forward to the next occurrence and
+    // keeps it active, instead of marking it done.
+    if done {
+        let (repeat, due, remind) = conn
+            .query_row(
+                "SELECT repeat, due_date, remind_at FROM tasks WHERE id = ?1",
+                [id],
+                |r| {
+                    Ok((
+                        r.get::<_, Option<String>>(0)?,
+                        r.get::<_, Option<String>>(1)?,
+                        r.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .map_err(|e| e.to_string())?;
+
+        if let Some(rule) = repeat.as_deref().filter(|s| !s.is_empty()) {
+            if let Some(next_due) = due.as_deref().and_then(|d| recur::advance_due(d, rule)) {
+                let next_remind = remind.as_deref().and_then(|r| recur::advance_remind(r, rule));
+                conn.execute(
+                    "UPDATE tasks SET due_date = ?1, remind_at = ?2, notified = 0 WHERE id = ?3",
+                    params![next_due, next_remind, id],
+                )
+                .map_err(|e| e.to_string())?;
+                return load_task(&conn, id).map_err(|e| e.to_string());
+            }
+        }
+    }
     if done {
         conn.execute(
             "UPDATE tasks SET status = 'done', completed_at = ?1 WHERE id = ?2",
@@ -188,7 +231,7 @@ pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
 
 #[tauri::command]
 pub fn delete_task(db: State<Db>, id: i64) -> CmdResult<()> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     conn.execute("DELETE FROM tasks WHERE id = ?1", [id])
         .map_err(|e| e.to_string())?;
     Ok(())
@@ -196,7 +239,7 @@ pub fn delete_task(db: State<Db>, id: i64) -> CmdResult<()> {
 
 #[tauri::command]
 pub fn list_labels(db: State<Db>) -> CmdResult<Vec<Label>> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     let mut stmt = conn
         .prepare("SELECT id, name, color FROM labels ORDER BY name COLLATE NOCASE")
         .map_err(|e| e.to_string())?;
@@ -216,7 +259,7 @@ pub fn list_labels(db: State<Db>) -> CmdResult<Vec<Label>> {
 
 #[tauri::command]
 pub fn create_label(db: State<Db>, name: String, color: String) -> CmdResult<Label> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     conn.execute(
         "INSERT INTO labels (name, color) VALUES (?1, ?2)",
         params![name.trim(), color],
@@ -232,7 +275,7 @@ pub fn create_label(db: State<Db>, name: String, color: String) -> CmdResult<Lab
 
 #[tauri::command]
 pub fn update_label(db: State<Db>, id: i64, name: String, color: String) -> CmdResult<Label> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     conn.execute(
         "UPDATE labels SET name = ?1, color = ?2 WHERE id = ?3",
         params![name.trim(), color, id],
@@ -247,7 +290,7 @@ pub fn update_label(db: State<Db>, id: i64, name: String, color: String) -> CmdR
 
 #[tauri::command]
 pub fn delete_label(db: State<Db>, id: i64) -> CmdResult<()> {
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     conn.execute("DELETE FROM labels WHERE id = ?1", [id])
         .map_err(|e| e.to_string())?;
     Ok(())

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,9 +1,20 @@
 use rusqlite::{params, Connection};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 /// Managed Tauri state: a single SQLite connection behind a mutex.
 /// The notification scheduler and the command handlers share this.
 pub struct Db(pub Mutex<Connection>);
+
+impl Db {
+    /// Borrow the connection. If a previous holder panicked while holding the
+    /// lock the mutex is poisoned; we recover the guard anyway rather than
+    /// cascading the panic to every later database call. Each command touches
+    /// the connection only briefly and leaves it in a consistent state, so the
+    /// data is safe to keep using.
+    pub fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
 
 /// Create the schema if it does not yet exist, then bring older
 /// databases up to date via `migrate`.
@@ -31,7 +42,8 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
             completed_at TEXT,
             order_index  REAL NOT NULL DEFAULT 0,
             notified     INTEGER NOT NULL DEFAULT 0,
-            pinned       INTEGER NOT NULL DEFAULT 0
+            pinned       INTEGER NOT NULL DEFAULT 0,
+            repeat       TEXT                -- daily|weekdays|weekly|monthly|yearly
         );
 
         CREATE TABLE IF NOT EXISTS task_labels (
@@ -39,6 +51,43 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
             label_id INTEGER NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
             PRIMARY KEY (task_id, label_id)
         );
+
+        -- Simple key/value app settings (e.g. startup_mode). Read by the
+        -- backend at launch and by the Settings screen at runtime.
+        CREATE TABLE IF NOT EXISTS settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        -- Per-task focus stopwatch sessions. A row with a NULL end_at is the
+        -- one currently running (at most one at a time). `seconds` is filled in
+        -- on stop; `notified` counts the 'still tracking' nudges already sent.
+        CREATE TABLE IF NOT EXISTS time_sessions (
+            id       INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+            start_at TEXT NOT NULL,   -- RFC3339
+            end_at   TEXT,            -- NULL while running
+            seconds  INTEGER,         -- duration, set on stop
+            notified INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_task ON time_sessions(task_id);
+
+        -- Standalone Pomodoro timer state (single row, id = 1). Persisted so
+        -- the timer survives restarts and keeps ticking while in the tray.
+        CREATE TABLE IF NOT EXISTS pomodoro (
+            id             INTEGER PRIMARY KEY CHECK (id = 1),
+            phase          TEXT NOT NULL DEFAULT 'focus',  -- focus|short|long
+            running        INTEGER NOT NULL DEFAULT 0,
+            start_at       TEXT,                            -- when the running segment began
+            accumulated    INTEGER NOT NULL DEFAULT 0,      -- secs elapsed before this segment
+            completed_focus INTEGER NOT NULL DEFAULT 0,     -- focus phases done in the set
+            notified       INTEGER NOT NULL DEFAULT 0,      -- phase-complete nudge sent?
+            focus_min      INTEGER NOT NULL DEFAULT 25,
+            short_min      INTEGER NOT NULL DEFAULT 5,
+            long_min       INTEGER NOT NULL DEFAULT 15,
+            long_every     INTEGER NOT NULL DEFAULT 4
+        );
+        INSERT OR IGNORE INTO pomodoro (id) VALUES (1);
 
         CREATE INDEX IF NOT EXISTS idx_tasks_status   ON tasks(status);
         CREATE INDEX IF NOT EXISTS idx_tasks_due      ON tasks(due_date);
@@ -72,6 +121,12 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         conn.execute("ALTER TABLE tasks ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", [])?;
     }
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_pinned ON tasks(pinned)", [])?;
+
+    // Recurring tasks: completing one rolls its due date / reminder forward to
+    // the next occurrence instead of marking it done (see `recur.rs`).
+    if !column_exists(conn, "tasks", "repeat") {
+        conn.execute("ALTER TABLE tasks ADD COLUMN repeat TEXT", [])?;
+    }
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,14 +2,22 @@ mod commands;
 mod db;
 mod models;
 mod quickwin;
+mod recur;
 mod scheduler;
+mod settings;
+mod timer;
 mod tray;
 
 use db::Db;
 use rusqlite::Connection;
 use std::sync::Mutex;
 use tauri::{Manager, WindowEvent};
+use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+
+/// Flag added to the launch-on-login command so the app can tell a login
+/// launch apart from the user opening it by hand.
+const AUTOSTART_FLAG: &str = "--autostart";
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -25,6 +33,13 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        // Launch-on-login. The registered command carries AUTOSTART_FLAG so the
+        // setup hook below can decide between opening the window and staying in
+        // the tray based on the user's `startup_mode` setting.
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            Some(vec![AUTOSTART_FLAG]),
+        ))
         // Global hotkey (Ctrl+Alt+A) to summon the quick-add window from anywhere.
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
@@ -49,6 +64,23 @@ pub fn run() {
             db::init(&conn).expect("failed to initialize schema");
             app.manage(Db(Mutex::new(conn)));
 
+            // The main window starts hidden (visible:false in tauri.conf.json)
+            // so a login launch can go straight to the tray without a flash.
+            // Reveal it now unless this is an autostart launch configured to
+            // start minimized to the tray.
+            let launched_at_startup = std::env::args().any(|a| a == AUTOSTART_FLAG);
+            let start_in_tray = {
+                let db = app.state::<Db>();
+                let conn = db.conn();
+                settings::read(&conn, "startup_mode").as_deref() == Some("tray")
+            };
+            if let Some(win) = app.get_webview_window("main") {
+                if !(launched_at_startup && start_in_tray) {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
+            }
+
             // Register the global quick-add hotkey. If the desktop
             // environment has already claimed Ctrl+Alt+A, log and carry on.
             if let Err(e) = app.global_shortcut().register(quickwin::quick_shortcut()) {
@@ -58,8 +90,9 @@ pub fn run() {
             // Start the reminder scheduler.
             scheduler::spawn(app.handle().clone());
 
-            // System-tray icon with Show / Quit.
+            // System-tray icon with focus controls + live timer status.
             tray::init(app)?;
+            tray::spawn_updater(app.handle().clone());
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -83,6 +116,20 @@ pub fn run() {
             commands::create_label,
             commands::update_label,
             commands::delete_label,
+            settings::get_setting,
+            settings::set_setting,
+            settings::get_autostart,
+            settings::set_autostart,
+            timer::start_timer,
+            timer::stop_timer,
+            timer::active_timer,
+            timer::focus_history,
+            timer::get_pomodoro,
+            timer::pomodoro_start,
+            timer::pomodoro_pause,
+            timer::pomodoro_reset,
+            timer::pomodoro_next,
+            timer::set_pomodoro_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,4 +1,17 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize a nullable, optional field so the three JSON states stay
+/// distinct: field absent -> `None` (leave unchanged), `null` -> `Some(None)`
+/// (clear the column), value -> `Some(Some(v))` (set it). Plain
+/// `Option<Option<T>>` collapses `null` and absent to `None`, which would make
+/// "clear" a silent no-op.
+fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::deserialize(de)?))
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Label {
@@ -21,6 +34,10 @@ pub struct Task {
     pub completed_at: Option<String>,
     pub order_index: f64,
     pub pinned: bool,
+    /// Recurrence rule: daily|weekdays|weekly|monthly|yearly, or None.
+    pub repeat: Option<String>,
+    /// Total focused seconds from completed stopwatch sessions.
+    pub tracked_seconds: i64,
     /// Label ids attached to this task.
     pub label_ids: Vec<i64>,
 }
@@ -35,6 +52,7 @@ pub struct NewTask {
     pub remind_at: Option<String>,
     pub priority: Option<i64>,
     pub label_ids: Option<Vec<i64>>,
+    pub repeat: Option<String>,
 }
 
 /// Payload for updating a task. `id` required; provided fields are applied.
@@ -43,10 +61,56 @@ pub struct NewTask {
 pub struct TaskPatch {
     pub id: i64,
     pub title: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
     pub notes: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub due_date: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
     pub remind_at: Option<Option<String>>,
     pub priority: Option<i64>,
     pub label_ids: Option<Vec<i64>>,
     pub pinned: Option<bool>,
+    /// `Some(None)` clears the recurrence; `Some(Some(rule))` sets it.
+    #[serde(default, deserialize_with = "double_option")]
+    pub repeat: Option<Option<String>>,
+}
+
+/// The currently running per-task stopwatch, if any.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveTimer {
+    pub task_id: i64,
+    pub title: String,
+    pub start_at: String,
+}
+
+/// A completed focus session, for the history view.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionLog {
+    pub id: i64,
+    pub task_id: i64,
+    pub title: String,
+    pub start_at: String,
+    pub end_at: String,
+    pub seconds: i64,
+}
+
+/// Standalone Pomodoro timer state. Elapsed time in the current phase is
+/// `accumulated + (now - start_at)` while running; the frontend derives the
+/// live countdown from `target` so it ticks smoothly without polling.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Pomodoro {
+    pub phase: String,
+    pub running: bool,
+    pub start_at: Option<String>,
+    pub accumulated: i64,
+    pub completed_focus: i64,
+    /// Seconds the current phase is meant to last.
+    pub target: i64,
+    pub focus_min: i64,
+    pub short_min: i64,
+    pub long_min: i64,
+    pub long_every: i64,
 }

--- a/src-tauri/src/recur.rs
+++ b/src-tauri/src/recur.rs
@@ -1,0 +1,46 @@
+//! Recurrence math for repeating tasks. A task's `repeat` rule is one of
+//! `daily | weekdays | weekly | monthly | yearly`. Completing such a task rolls
+//! its due date (and reminder, keeping the same wall-clock time) forward to the
+//! next occurrence instead of marking it done.
+
+use chrono::{DateTime, Datelike, Days, Local, Months, NaiveDate, TimeZone, Weekday};
+
+/// The next occurrence of `date` under `rule`, or `None` for an unknown rule.
+pub fn next_date(date: NaiveDate, rule: &str) -> Option<NaiveDate> {
+    match rule {
+        "daily" => date.checked_add_days(Days::new(1)),
+        "weekly" => date.checked_add_days(Days::new(7)),
+        "weekdays" => {
+            // Skip Saturday and Sunday: Fri -> Mon, Sat -> Mon, etc.
+            let mut d = date.checked_add_days(Days::new(1))?;
+            while matches!(d.weekday(), Weekday::Sat | Weekday::Sun) {
+                d = d.checked_add_days(Days::new(1))?;
+            }
+            Some(d)
+        }
+        // `checked_add_months` clamps overflowing days (Jan 31 -> Feb 28/29).
+        "monthly" => date.checked_add_months(Months::new(1)),
+        "yearly" => date.checked_add_months(Months::new(12)),
+        _ => None,
+    }
+}
+
+/// Advance a stored due date (`YYYY-MM-DD`) to its next occurrence.
+pub fn advance_due(due: &str, rule: &str) -> Option<String> {
+    let d = NaiveDate::parse_from_str(due, "%Y-%m-%d").ok()?;
+    Some(next_date(d, rule)?.format("%Y-%m-%d").to_string())
+}
+
+/// Advance a stored reminder instant (RFC3339) to the same local time on the
+/// next occurrence.
+pub fn advance_remind(remind: &str, rule: &str) -> Option<String> {
+    let dt = DateTime::parse_from_rfc3339(remind)
+        .ok()?
+        .with_timezone(&Local);
+    let naive = next_date(dt.date_naive(), rule)?.and_time(dt.time());
+    let local = Local
+        .from_local_datetime(&naive)
+        .single()
+        .or_else(|| Local.from_local_datetime(&naive).earliest())?;
+    Some(local.to_rfc3339())
+}

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -39,6 +39,8 @@ fn tick(app: &AppHandle) -> Result<(), String> {
         // Let an open window surface an in-app reminder toast too.
         let _ = app.emit("reminder-fired", r.clone());
     }
+    // Focus timers (Pomodoro + per-task stopwatch) also need background nudges.
+    crate::timer::poll(app);
     Ok(())
 }
 
@@ -46,7 +48,7 @@ fn tick(app: &AppHandle) -> Result<(), String> {
 /// been notified yet, then mark them notified in the same pass.
 fn collect_due(app: &AppHandle) -> Result<Vec<DueReminder>, String> {
     let db = app.state::<Db>();
-    let conn = db.0.lock().unwrap();
+    let conn = db.conn();
     let now = Local::now();
 
     let mut stmt = conn

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,54 @@
+use crate::db::Db;
+use rusqlite::{params, Connection, OptionalExtension};
+use tauri::{AppHandle, State};
+use tauri_plugin_autostart::ManagerExt;
+
+/// Read a setting value, or `None` if it was never set.
+pub fn read(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row("SELECT value FROM settings WHERE key = ?1", [key], |r| {
+        r.get::<_, String>(0)
+    })
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// Upsert a setting value.
+fn write(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![key, value],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_setting(db: State<Db>, key: String) -> Result<Option<String>, String> {
+    Ok(read(&db.conn(), &key))
+}
+
+#[tauri::command]
+pub fn set_setting(db: State<Db>, key: String, value: String) -> Result<(), String> {
+    write(&db.conn(), &key, &value).map_err(|e| e.to_string())
+}
+
+/// Whether todofy is registered to launch when the user logs in.
+#[tauri::command]
+pub fn get_autostart(app: AppHandle) -> Result<bool, String> {
+    app.autolaunch().is_enabled().map_err(|e| e.to_string())
+}
+
+/// Enable or disable launch-on-login. The registered command carries the
+/// `--autostart` flag (see `lib.rs`), which the app reads at startup to decide
+/// whether to open its window or stay in the tray per the `startup_mode` setting.
+#[tauri::command]
+pub fn set_autostart(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let manager = app.autolaunch();
+    if enabled {
+        manager.enable()
+    } else {
+        manager.disable()
+    }
+    .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/timer.rs
+++ b/src-tauri/src/timer.rs
@@ -1,0 +1,410 @@
+//! Two independent focus timers, both backed by SQLite so they keep counting
+//! while the window is hidden in the tray and survive a restart.
+//!
+//! * Per-task stopwatch — `time_sessions` rows; the one with a NULL `end_at`
+//!   is running. Neither timer auto-stops: `poll` only fires reminder
+//!   notifications and lets them keep running.
+//! * Standalone Pomodoro — the single `pomodoro` row; elapsed time in the
+//!   current phase is `accumulated + (now - start_at)` while running.
+
+use crate::db::Db;
+use crate::models::{ActiveTimer, Pomodoro, SessionLog};
+use chrono::{DateTime, Local};
+use rusqlite::{params, Connection, OptionalExtension};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_notification::NotificationExt;
+
+fn now_iso() -> String {
+    Local::now().to_rfc3339()
+}
+
+/// Whole seconds elapsed since an RFC3339 instant (never negative).
+fn secs_since(iso: &str) -> i64 {
+    DateTime::parse_from_rfc3339(iso)
+        .map(|dt| (Local::now().timestamp() - dt.timestamp()).max(0))
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------- stopwatch
+
+fn read_active(conn: &Connection) -> rusqlite::Result<Option<ActiveTimer>> {
+    conn.query_row(
+        "SELECT s.task_id, t.title, s.start_at
+         FROM time_sessions s JOIN tasks t ON t.id = s.task_id
+         WHERE s.end_at IS NULL
+         ORDER BY s.id DESC LIMIT 1",
+        [],
+        |r| {
+            Ok(ActiveTimer {
+                task_id: r.get(0)?,
+                title: r.get(1)?,
+                start_at: r.get(2)?,
+            })
+        },
+    )
+    .optional()
+}
+
+/// Stop every running session, recording each one's duration.
+fn close_open_sessions(conn: &Connection) -> rusqlite::Result<()> {
+    let now = now_iso();
+    let mut stmt = conn.prepare("SELECT id, start_at FROM time_sessions WHERE end_at IS NULL")?;
+    let rows: Vec<(i64, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    for (id, start) in rows {
+        conn.execute(
+            "UPDATE time_sessions SET end_at = ?1, seconds = ?2 WHERE id = ?3",
+            params![now, secs_since(&start), id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Start tracking a task. Any other running session is stopped first, so at
+/// most one stopwatch runs at a time.
+#[tauri::command]
+pub fn start_timer(db: State<Db>, id: i64) -> Result<Option<ActiveTimer>, String> {
+    let conn = db.conn();
+    close_open_sessions(&conn).map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO time_sessions (task_id, start_at) VALUES (?1, ?2)",
+        params![id, now_iso()],
+    )
+    .map_err(|e| e.to_string())?;
+    read_active(&conn).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn stop_timer(db: State<Db>) -> Result<(), String> {
+    close_open_sessions(&db.conn()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn active_timer(db: State<Db>) -> Result<Option<ActiveTimer>, String> {
+    read_active(&db.conn()).map_err(|e| e.to_string())
+}
+
+/// Recent completed focus sessions, newest first, for the history view.
+#[tauri::command]
+pub fn focus_history(db: State<Db>, limit: i64) -> Result<Vec<SessionLog>, String> {
+    let conn = db.conn();
+    let lim = if limit <= 0 { 200 } else { limit };
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id, s.task_id, t.title, s.start_at, s.end_at, s.seconds
+             FROM time_sessions s JOIN tasks t ON t.id = s.task_id
+             WHERE s.end_at IS NOT NULL
+             ORDER BY s.start_at DESC LIMIT ?1",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([lim], |r| {
+            Ok(SessionLog {
+                id: r.get(0)?,
+                task_id: r.get(1)?,
+                title: r.get(2)?,
+                start_at: r.get(3)?,
+                end_at: r.get(4)?,
+                seconds: r.get::<_, Option<i64>>(5)?.unwrap_or(0),
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+// ---------------------------------------------------------------- pomodoro
+
+fn phase_target(phase: &str, focus: i64, short: i64, long: i64) -> i64 {
+    let minutes = match phase {
+        "short" => short,
+        "long" => long,
+        _ => focus,
+    };
+    minutes * 60
+}
+
+fn read_pomodoro(conn: &Connection) -> rusqlite::Result<Pomodoro> {
+    conn.query_row(
+        "SELECT phase, running, start_at, accumulated, completed_focus,
+                focus_min, short_min, long_min, long_every
+         FROM pomodoro WHERE id = 1",
+        [],
+        |r| {
+            let phase: String = r.get(0)?;
+            let focus: i64 = r.get(5)?;
+            let short: i64 = r.get(6)?;
+            let long: i64 = r.get(7)?;
+            Ok(Pomodoro {
+                target: phase_target(&phase, focus, short, long),
+                phase,
+                running: r.get::<_, i64>(1)? != 0,
+                start_at: r.get(2)?,
+                accumulated: r.get(3)?,
+                completed_focus: r.get(4)?,
+                focus_min: focus,
+                short_min: short,
+                long_min: long,
+                long_every: r.get(8)?,
+            })
+        },
+    )
+}
+
+#[tauri::command]
+pub fn get_pomodoro(db: State<Db>) -> Result<Pomodoro, String> {
+    read_pomodoro(&db.conn()).map_err(|e| e.to_string())
+}
+
+/// Start or resume the current phase.
+#[tauri::command]
+pub fn pomodoro_start(db: State<Db>) -> Result<Pomodoro, String> {
+    let conn = db.conn();
+    conn.execute(
+        "UPDATE pomodoro SET running = 1, start_at = ?1 WHERE id = 1 AND running = 0",
+        params![now_iso()],
+    )
+    .map_err(|e| e.to_string())?;
+    read_pomodoro(&conn).map_err(|e| e.to_string())
+}
+
+/// Pause, folding the running segment into `accumulated`.
+#[tauri::command]
+pub fn pomodoro_pause(db: State<Db>) -> Result<Pomodoro, String> {
+    let conn = db.conn();
+    let p = read_pomodoro(&conn).map_err(|e| e.to_string())?;
+    if p.running {
+        let add = p.start_at.as_deref().map(secs_since).unwrap_or(0);
+        conn.execute(
+            "UPDATE pomodoro SET running = 0, start_at = NULL, accumulated = accumulated + ?1 WHERE id = 1",
+            params![add],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    read_pomodoro(&conn).map_err(|e| e.to_string())
+}
+
+/// Reset the current phase's clock (keeps the phase and set progress).
+#[tauri::command]
+pub fn pomodoro_reset(db: State<Db>) -> Result<Pomodoro, String> {
+    let conn = db.conn();
+    conn.execute(
+        "UPDATE pomodoro SET running = 0, start_at = NULL, accumulated = 0, notified = 0 WHERE id = 1",
+        [],
+    )
+    .map_err(|e| e.to_string())?;
+    read_pomodoro(&conn).map_err(|e| e.to_string())
+}
+
+/// Advance to the next phase (focus -> short/long break -> focus) and start it.
+#[tauri::command]
+pub fn pomodoro_next(db: State<Db>) -> Result<Pomodoro, String> {
+    let conn = db.conn();
+    let p = read_pomodoro(&conn).map_err(|e| e.to_string())?;
+    let (next_phase, completed) = if p.phase == "focus" {
+        let c = p.completed_focus + 1;
+        let long_every = p.long_every.max(1);
+        (if c % long_every == 0 { "long" } else { "short" }, c)
+    } else {
+        ("focus", p.completed_focus)
+    };
+    conn.execute(
+        "UPDATE pomodoro SET phase = ?1, completed_focus = ?2, accumulated = 0,
+                notified = 0, running = 1, start_at = ?3 WHERE id = 1",
+        params![next_phase, completed, now_iso()],
+    )
+    .map_err(|e| e.to_string())?;
+    read_pomodoro(&conn).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_pomodoro_config(
+    db: State<Db>,
+    focus_min: i64,
+    short_min: i64,
+    long_min: i64,
+    long_every: i64,
+) -> Result<Pomodoro, String> {
+    let conn = db.conn();
+    conn.execute(
+        "UPDATE pomodoro SET focus_min = ?1, short_min = ?2, long_min = ?3, long_every = ?4 WHERE id = 1",
+        params![
+            focus_min.max(1),
+            short_min.max(1),
+            long_min.max(1),
+            long_every.max(1)
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    read_pomodoro(&conn).map_err(|e| e.to_string())
+}
+
+// ----------------------------------------------------------------- polling
+
+/// Called from the scheduler thread. Fires reminder notifications for a
+/// finished Pomodoro phase and for long-running stopwatch sessions, without
+/// stopping either timer.
+pub fn poll(app: &AppHandle) {
+    let db = app.state::<Db>();
+    let conn = db.conn();
+    let mut pomodoro_changed = false;
+
+    // Pomodoro phase reached its target — nudge once, keep running (overtime).
+    if let Ok(p) = read_pomodoro(&conn) {
+        if p.running {
+            let elapsed = p.accumulated + p.start_at.as_deref().map(secs_since).unwrap_or(0);
+            let notified: i64 = conn
+                .query_row("SELECT notified FROM pomodoro WHERE id = 1", [], |r| r.get(0))
+                .unwrap_or(0);
+            if elapsed >= p.target && notified == 0 {
+                let (title, body) = if p.phase == "focus" {
+                    ("Focus session done", "Time for a break · todofy")
+                } else {
+                    ("Break's over", "Back to focus · todofy")
+                };
+                let _ = app.notification().builder().title(title).body(body).show();
+                let _ = conn.execute("UPDATE pomodoro SET notified = 1 WHERE id = 1", []);
+                pomodoro_changed = true;
+            }
+        }
+    }
+
+    // Long-running stopwatch: nudge once per elapsed hour, keep it running.
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT s.id, t.title, s.start_at, s.notified
+         FROM time_sessions s JOIN tasks t ON t.id = s.task_id
+         WHERE s.end_at IS NULL",
+    ) {
+        let rows: Vec<(i64, String, String, i64)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+            .and_then(|it| it.collect())
+            .unwrap_or_default();
+        for (id, title, start, notified) in rows {
+            let hours = secs_since(&start) / 3600;
+            if hours > notified {
+                let _ = app
+                    .notification()
+                    .builder()
+                    .title("Still tracking time")
+                    .body(format!("“{title}” — {hours}h and counting · todofy"))
+                    .show();
+                let _ = conn.execute(
+                    "UPDATE time_sessions SET notified = ?1 WHERE id = ?2",
+                    params![hours, id],
+                );
+            }
+        }
+    }
+
+    drop(conn);
+    if pomodoro_changed {
+        let _ = app.emit("pomodoro-updated", ());
+    }
+}
+
+// ------------------------------------------------------------- tray controls
+
+fn clock_mmss(secs: i64) -> String {
+    let s = secs.max(0);
+    format!("{}:{:02}", s / 60, s % 60)
+}
+
+/// Signed clock: overtime renders as "+m:ss".
+fn clock_signed(secs: i64) -> String {
+    if secs < 0 {
+        format!("+{}", clock_mmss(-secs))
+    } else {
+        clock_mmss(secs)
+    }
+}
+
+/// Is either timer currently running? (cheap, safe to call off the main thread)
+pub fn any_running(app: &AppHandle) -> bool {
+    let db = app.state::<Db>();
+    let conn = db.conn();
+    let task = read_active(&conn).ok().flatten().is_some();
+    let pomo = read_pomodoro(&conn).map(|p| p.running).unwrap_or(false);
+    task || pomo
+}
+
+/// What the tray should show right now: `(title, tooltip, pomodoro toggle
+/// label, is a task timer running)`. Title is the compact clock shown next to
+/// the icon; tooltip/status is the descriptive line.
+pub fn tray_display(app: &AppHandle) -> (String, String, String, bool) {
+    let db = app.state::<Db>();
+    let conn = db.conn();
+    let active = read_active(&conn).ok().flatten();
+    let pomo = read_pomodoro(&conn).ok();
+
+    let task_running = active.is_some();
+    let pomo_running = pomo.as_ref().map(|p| p.running).unwrap_or(false);
+    let pomo_label = if pomo_running { "Pause focus" } else { "Start focus" }.to_string();
+
+    let mut title = String::new();
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(a) = &active {
+        let e = secs_since(&a.start_at);
+        title = clock_mmss(e);
+        parts.push(format!("Tracking: {} ({})", a.title, clock_mmss(e)));
+    }
+    if let Some(p) = &pomo {
+        if p.running {
+            let elapsed = p.accumulated + p.start_at.as_deref().map(secs_since).unwrap_or(0);
+            let remaining = p.target - elapsed;
+            if title.is_empty() {
+                title = clock_signed(remaining);
+            }
+            let phase = match p.phase.as_str() {
+                "short" => "Short break",
+                "long" => "Long break",
+                _ => "Focus",
+            };
+            parts.push(format!("{} {}", phase, clock_signed(remaining)));
+        }
+    }
+
+    let tip = if parts.is_empty() {
+        "todofy — no timer running".to_string()
+    } else {
+        parts.join(" · ")
+    };
+    (title, tip, pomo_label, task_running)
+}
+
+/// Toggle the Pomodoro from the tray (start/resume if paused, else pause).
+pub fn tray_toggle_pomodoro(app: &AppHandle) {
+    {
+        let db = app.state::<Db>();
+        let conn = db.conn();
+        if let Ok(p) = read_pomodoro(&conn) {
+            let _ = if p.running {
+                let add = p.start_at.as_deref().map(secs_since).unwrap_or(0);
+                conn.execute(
+                    "UPDATE pomodoro SET running = 0, start_at = NULL, accumulated = accumulated + ?1 WHERE id = 1",
+                    params![add],
+                )
+            } else {
+                conn.execute(
+                    "UPDATE pomodoro SET running = 1, start_at = ?1 WHERE id = 1",
+                    params![now_iso()],
+                )
+            };
+        }
+    }
+    let _ = app.emit("timers-changed", ());
+    crate::tray::refresh(app);
+}
+
+/// Stop the running per-task stopwatch from the tray.
+pub fn tray_stop_task(app: &AppHandle) {
+    {
+        let db = app.state::<Db>();
+        let conn = db.conn();
+        let _ = close_open_sessions(&conn);
+    }
+    let _ = app.emit("timers-changed", ());
+    crate::tray::refresh(app);
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,11 +1,20 @@
+use crate::timer;
 use tauri::{
-    menu::{Menu, MenuItem},
+    menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    App, Manager,
+    App, AppHandle, Manager, Wry,
 };
 
+/// Menu items the timer updater keeps in sync, held in managed state so the
+/// background thread can reach them.
+pub struct TrayMenu {
+    status: MenuItem<Wry>,
+    pomodoro: MenuItem<Wry>,
+    stop_task: MenuItem<Wry>,
+}
+
 /// Bring the main window to the foreground.
-fn show_main(app: &tauri::AppHandle) {
+fn show_main(app: &AppHandle) {
     if let Some(win) = app.get_webview_window("main") {
         let _ = win.show();
         let _ = win.unminimize();
@@ -13,12 +22,28 @@ fn show_main(app: &tauri::AppHandle) {
     }
 }
 
-/// Install a system-tray icon with a Show / Quit menu. Left-clicking the
-/// tray icon focuses the window.
+/// Install a system-tray icon. The menu carries a live timer status line plus
+/// focus controls (start/pause Pomodoro, stop the task stopwatch) alongside
+/// Show / Quit. Left-clicking the icon focuses the window.
 pub fn init(app: &App) -> tauri::Result<()> {
+    let status = MenuItem::with_id(app, "status", "No timer running", false, None::<&str>)?;
+    let pomodoro = MenuItem::with_id(app, "pomodoro", "Start focus", true, None::<&str>)?;
+    let stop_task = MenuItem::with_id(app, "stop_task", "Stop task timer", false, None::<&str>)?;
     let show = MenuItem::with_id(app, "show", "Show todofy", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&show, &quit])?;
+    let sep1 = PredefinedMenuItem::separator(app)?;
+    let sep2 = PredefinedMenuItem::separator(app)?;
+
+    let menu = Menu::with_items(
+        app,
+        &[&status, &sep1, &pomodoro, &stop_task, &sep2, &show, &quit],
+    )?;
+
+    app.manage(TrayMenu {
+        status: status.clone(),
+        pomodoro: pomodoro.clone(),
+        stop_task: stop_task.clone(),
+    });
 
     TrayIconBuilder::with_id("main-tray")
         .icon(app.default_window_icon().unwrap().clone())
@@ -28,6 +53,8 @@ pub fn init(app: &App) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id.as_ref() {
             "show" => show_main(app),
             "quit" => app.exit(0),
+            "pomodoro" => timer::tray_toggle_pomodoro(app),
+            "stop_task" => timer::tray_stop_task(app),
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -43,4 +70,44 @@ pub fn init(app: &App) -> tauri::Result<()> {
         .build(app)?;
 
     Ok(())
+}
+
+/// Push the given display state onto the tray icon and menu. Must run on the
+/// main thread (GTK requirement on Linux).
+pub fn apply(app: &AppHandle, display: (String, String, String, bool)) {
+    let (title, tooltip, pomo_label, task_running) = display;
+    if let Some(menu) = app.try_state::<TrayMenu>() {
+        let _ = menu.status.set_text(&tooltip);
+        let _ = menu.pomodoro.set_text(&pomo_label);
+        let _ = menu.stop_task.set_enabled(task_running);
+    }
+    if let Some(tray) = app.tray_by_id("main-tray") {
+        let _ = tray.set_tooltip(Some(&tooltip));
+        // Shown next to the icon on macOS and appindicator-based Linux DEs.
+        let _ = tray.set_title(Some(&title));
+    }
+}
+
+/// Recompute and apply the tray state now (used right after a menu action).
+pub fn refresh(app: &AppHandle) {
+    apply(app, timer::tray_display(app));
+}
+
+/// Background thread that keeps the tray clock ticking every second while a
+/// timer runs, and clears it once on the transition to idle. Computing the
+/// strings off-thread keeps the main-thread hop to just the GTK calls.
+pub fn spawn_updater(app: AppHandle) {
+    std::thread::spawn(move || {
+        let mut was_running = false;
+        loop {
+            let running = timer::any_running(&app);
+            if running || was_running {
+                let display = timer::tray_display(&app);
+                let handle = app.clone();
+                let _ = app.run_on_main_thread(move || apply(&handle, display));
+            }
+            was_running = running;
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+    });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "todofy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.unifybrowse.todofy",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -15,7 +15,8 @@
         "label": "main",
         "title": "todofy",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "visible": false
       },
       {
         "label": "quickadd",
@@ -34,7 +35,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost; font-src 'self'"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,14 @@ import { TaskList } from "./components/TaskList";
 import { TaskDetail } from "./components/TaskDetail";
 import { ReminderToasts } from "./components/ReminderToasts";
 import { ConfirmDialog } from "./components/ConfirmDialog";
+import { FocusWidget } from "./components/FocusWidget";
 import { ChevronLeftIcon, ChevronRightIcon } from "./components/Icons";
 
 export function App() {
   const load = useStore((s) => s.load);
+  const loadTimers = useStore((s) => s.loadTimers);
+  const refreshPomodoro = useStore((s) => s.refreshPomodoro);
+  const onTimersChanged = useStore((s) => s.onTimersChanged);
   const pushReminder = useStore((s) => s.pushReminder);
   const theme = useStore((s) => s.theme);
   const tasks = useStore((s) => s.tasks);
@@ -27,6 +31,7 @@ export function App() {
 
   useEffect(() => {
     load();
+    loadTimers();
     // Ask for desktop notification permission once, up front.
     (async () => {
       if (!(await isPermissionGranted())) {
@@ -40,9 +45,15 @@ export function App() {
     });
     // Refresh when a task is added from the quick-add window.
     const unAdded = listen("todo-added", () => load());
+    // The scheduler advanced the Pomodoro (e.g. a phase finished) — re-sync.
+    const unPomo = listen("pomodoro-updated", () => refreshPomodoro());
+    // A timer was started/stopped from the tray menu — re-sync all timer state.
+    const unTimers = listen("timers-changed", () => onTimersChanged());
     return () => {
       unlisten.then((off) => off());
       unAdded.then((off) => off());
+      unPomo.then((off) => off());
+      unTimers.then((off) => off());
     };
   }, []);
 
@@ -75,6 +86,7 @@ export function App() {
 
       <TaskList />
       <TaskDetail />
+      <FocusWidget />
       <ReminderToasts />
       <ConfirmDialog />
     </div>

--- a/src/components/FocusView.tsx
+++ b/src/components/FocusView.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from "preact/hooks";
+import { useStore } from "../store";
+import type { PomodoroPhase, SessionLog } from "../types";
+import { api } from "../lib/api";
+import { clock, formatDuration, secondsSince } from "../lib/duration";
+import { toLocalDate, today } from "../lib/dates";
+import {
+  PauseIcon,
+  PlayIcon,
+  RotateIcon,
+  SkipIcon,
+  TimerIcon,
+} from "./Icons";
+
+const PHASE_LABEL: Record<PomodoroPhase, string> = {
+  focus: "Focus",
+  short: "Short break",
+  long: "Long break",
+};
+
+export function FocusView() {
+  const {
+    pomodoro,
+    pomodoroStart,
+    pomodoroPause,
+    pomodoroReset,
+    pomodoroNext,
+    setPomodoroConfig,
+    activeTimer,
+  } = useStore();
+
+  const [history, setHistory] = useState<SessionLog[]>([]);
+  const [, setNow] = useState(Date.now());
+
+  // Reload history whenever a session ends (activeTimer transitions to null).
+  useEffect(() => {
+    api.focusHistory().then(setHistory).catch(() => {});
+  }, [activeTimer]);
+
+  // Tick while the Pomodoro runs so the countdown updates.
+  useEffect(() => {
+    if (!pomodoro?.running) return;
+    const i = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(i);
+  }, [pomodoro?.running]);
+
+  const p = pomodoro;
+  const elapsed = p
+    ? p.accumulated + (p.running && p.startAt ? secondsSince(p.startAt) : 0)
+    : 0;
+  const remaining = p ? p.target - elapsed : 0;
+  const overtime = remaining < 0;
+
+  return (
+    <main class="flex flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
+      <header class="shrink-0 px-8 pt-8 pb-4">
+        <h2 class="text-2xl font-semibold tracking-tight">Focus</h2>
+        <p class="mt-0.5 text-sm text-[var(--color-muted)]">
+          Run a Pomodoro, tune its lengths, and review your focus history
+        </p>
+      </header>
+
+      <div class="mx-auto w-full max-w-2xl flex-1 overflow-y-auto px-8 pt-2 pb-8">
+        {/* Pomodoro */}
+        {p && (
+          <section class="mb-6 flex flex-col items-center gap-4 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-8">
+            <span
+              class={`rounded-full px-3 py-1 text-xs font-medium ${
+                p.phase === "focus"
+                  ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                  : "bg-[var(--color-surface-2)] text-[var(--color-success)]"
+              }`}
+            >
+              {PHASE_LABEL[p.phase]}
+            </span>
+
+            <span
+              class={`font-mono text-6xl font-semibold tabular-nums ${
+                overtime ? "text-[var(--color-warning)]" : "text-[var(--color-text)]"
+              }`}
+            >
+              {clock(remaining)}
+            </span>
+
+            <p class="text-xs text-[var(--color-faint)]">
+              {p.completedFocus} focus session{p.completedFocus === 1 ? "" : "s"} completed
+            </p>
+
+            <div class="flex items-center gap-3">
+              <button
+                onClick={pomodoroReset}
+                title="Reset phase"
+                class="grid h-11 w-11 place-items-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+              >
+                <RotateIcon width={18} height={18} />
+              </button>
+              <button
+                onClick={p.running ? pomodoroPause : pomodoroStart}
+                class="grid h-14 w-14 place-items-center rounded-full bg-[var(--color-accent)] text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+                title={p.running ? "Pause" : "Start"}
+              >
+                {p.running ? (
+                  <PauseIcon width={24} height={24} />
+                ) : (
+                  <PlayIcon width={24} height={24} />
+                )}
+              </button>
+              <button
+                onClick={pomodoroNext}
+                title="Skip to next phase"
+                class="grid h-11 w-11 place-items-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+              >
+                <SkipIcon width={18} height={18} />
+              </button>
+            </div>
+          </section>
+        )}
+
+        {/* Settings */}
+        {p && (
+          <section class="mb-6">
+            <h3 class="mb-2 px-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+              Pomodoro lengths
+            </h3>
+            <div class="grid grid-cols-2 gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-4 sm:grid-cols-4">
+              <NumberField
+                label="Focus"
+                value={p.focusMin}
+                onCommit={(v) => setPomodoroConfig(v, p.shortMin, p.longMin, p.longEvery)}
+              />
+              <NumberField
+                label="Short break"
+                value={p.shortMin}
+                onCommit={(v) => setPomodoroConfig(p.focusMin, v, p.longMin, p.longEvery)}
+              />
+              <NumberField
+                label="Long break"
+                value={p.longMin}
+                onCommit={(v) => setPomodoroConfig(p.focusMin, p.shortMin, v, p.longEvery)}
+              />
+              <NumberField
+                label="Long every"
+                value={p.longEvery}
+                onCommit={(v) => setPomodoroConfig(p.focusMin, p.shortMin, p.longMin, v)}
+              />
+            </div>
+          </section>
+        )}
+
+        {/* History */}
+        <History sessions={history} />
+      </div>
+    </main>
+  );
+}
+
+function History({ sessions }: { sessions: SessionLog[] }) {
+  const t = today();
+  const weekAgo = toLocalDate(new Date(Date.now() - 6 * 86400000));
+  const todayTotal = sum(sessions.filter((s) => toLocalDate(new Date(s.startAt)) === t));
+  const weekTotal = sum(sessions.filter((s) => toLocalDate(new Date(s.startAt)) >= weekAgo));
+  const allTotal = sum(sessions);
+
+  // Group by local day, newest first (the list already arrives sorted desc).
+  const groups: { day: string; items: SessionLog[] }[] = [];
+  for (const s of sessions) {
+    const day = toLocalDate(new Date(s.startAt));
+    const last = groups[groups.length - 1];
+    if (last && last.day === day) last.items.push(s);
+    else groups.push({ day, items: [s] });
+  }
+
+  return (
+    <section>
+      <h3 class="mb-2 px-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+        History
+      </h3>
+
+      <div class="mb-3 grid grid-cols-3 gap-3">
+        <Stat label="Today" value={formatDuration(todayTotal)} />
+        <Stat label="This week" value={formatDuration(weekTotal)} />
+        <Stat label="Tracked total" value={formatDuration(allTotal)} />
+      </div>
+
+      {sessions.length === 0 ? (
+        <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-8 text-center text-sm text-[var(--color-muted)]">
+          No focus sessions yet. Press play on a task to start tracking.
+        </div>
+      ) : (
+        <div class="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+          {groups.map((g) => (
+            <div key={g.day}>
+              <div class="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface-2)] px-4 py-1.5">
+                <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+                  {dayLabel(g.day)}
+                </span>
+                <span class="text-[11px] text-[var(--color-faint)]">
+                  {formatDuration(sum(g.items))}
+                </span>
+              </div>
+              {g.items.map((s) => (
+                <div
+                  key={s.id}
+                  class="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2.5 last:border-b-0"
+                >
+                  <TimerIcon width={14} height={14} class="shrink-0 text-[var(--color-faint)]" />
+                  <span class="min-w-0 flex-1 truncate text-sm text-[var(--color-text)]">
+                    {s.title}
+                  </span>
+                  <span class="shrink-0 text-xs text-[var(--color-muted)]">
+                    {timeRange(s.startAt, s.endAt)}
+                  </span>
+                  <span class="shrink-0 font-mono text-xs tabular-nums text-[var(--color-muted)]">
+                    {formatDuration(s.seconds)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div class="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-3 text-center">
+      <p class="text-lg font-semibold tabular-nums text-[var(--color-text)]">{value}</p>
+      <p class="mt-0.5 text-[11px] uppercase tracking-wider text-[var(--color-faint)]">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+/** Small labelled number input that commits on blur / Enter. */
+function NumberField({
+  label,
+  value,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  onCommit: (value: number) => void;
+}) {
+  const [text, setText] = useState(String(value));
+  useEffect(() => setText(String(value)), [value]);
+
+  const commit = () => {
+    const n = Math.max(1, Math.round(Number(text) || value));
+    if (n !== value) onCommit(n);
+    setText(String(n));
+  };
+
+  return (
+    <label class="flex flex-col gap-1">
+      <span class="text-[10px] font-medium uppercase tracking-wider text-[var(--color-faint)]">
+        {label}
+      </span>
+      <input
+        type="number"
+        min={1}
+        value={text}
+        onInput={(e) => setText(e.currentTarget.value)}
+        onBlur={commit}
+        onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+        class="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1.5 text-sm outline-none transition-colors focus:border-[var(--color-accent)]"
+      />
+    </label>
+  );
+}
+
+function sum(sessions: SessionLog[]): number {
+  return sessions.reduce((acc, s) => acc + s.seconds, 0);
+}
+
+function dayLabel(day: string): string {
+  const t = today();
+  if (day === t) return "Today";
+  if (day === toLocalDate(new Date(Date.now() - 86400000))) return "Yesterday";
+  return new Date(day + "T00:00:00").toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function timeRange(start: string, end: string): string {
+  const fmt = (iso: string) =>
+    new Date(iso).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  return `${fmt(start)} – ${fmt(end)}`;
+}

--- a/src/components/FocusWidget.tsx
+++ b/src/components/FocusWidget.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "preact/hooks";
+import { useStore } from "../store";
+import type { PomodoroPhase } from "../types";
+import { clock, formatDuration, secondsSince } from "../lib/duration";
+import {
+  CloseIcon,
+  ExpandIcon,
+  PauseIcon,
+  PlayIcon,
+  RotateIcon,
+  SkipIcon,
+  StopIcon,
+} from "./Icons";
+
+const PHASE_LABEL: Record<PomodoroPhase, string> = {
+  focus: "Focus",
+  short: "Short break",
+  long: "Long break",
+};
+
+export function FocusWidget() {
+  const {
+    showFocus,
+    toggleFocus,
+    pomodoro,
+    activeTimer,
+    pomodoroStart,
+    pomodoroPause,
+    pomodoroReset,
+    pomodoroNext,
+    select,
+    setView,
+    stopTaskTimer,
+  } = useStore();
+
+  // Re-render every second so the countdowns tick.
+  const [, setNow] = useState(Date.now());
+  useEffect(() => {
+    const running = pomodoro?.running || !!activeTimer;
+    if (!running) return;
+    const i = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(i);
+  }, [pomodoro?.running, activeTimer]);
+
+  if (!showFocus) return null;
+
+  const p = pomodoro;
+  const elapsed = p
+    ? p.accumulated + (p.running && p.startAt ? secondsSince(p.startAt) : 0)
+    : 0;
+  const remaining = p ? p.target - elapsed : 0;
+  const overtime = remaining < 0;
+  const activeElapsed = activeTimer ? secondsSince(activeTimer.startAt) : 0;
+
+  return (
+    <div class="fixed bottom-4 left-4 z-50 w-72 animate-fade-rise overflow-hidden rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] shadow-2xl shadow-black/50">
+      {/* Header */}
+      <div class="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2.5">
+        <span class="text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+          Focus
+        </span>
+        <div class="flex items-center gap-1">
+          <button
+            onClick={() => setView({ kind: "focus" })}
+            class="text-[var(--color-faint)] hover:text-[var(--color-text)]"
+            title="Open focus screen"
+          >
+            <ExpandIcon width={15} height={15} />
+          </button>
+          <button
+            onClick={toggleFocus}
+            class="text-[var(--color-faint)] hover:text-[var(--color-text)]"
+            title="Hide"
+          >
+            <CloseIcon width={16} height={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Pomodoro */}
+      {p && (
+        <div class="flex flex-col items-center gap-3 px-4 py-4">
+          <span
+            class={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              p.phase === "focus"
+                ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                : "bg-[var(--color-surface-2)] text-[var(--color-success)]"
+            }`}
+          >
+            {PHASE_LABEL[p.phase]}
+          </span>
+
+          <span
+            class={`font-mono text-4xl font-semibold tabular-nums ${
+              overtime ? "text-[var(--color-warning)]" : "text-[var(--color-text)]"
+            }`}
+          >
+            {clock(remaining)}
+          </span>
+
+          {p.completedFocus > 0 && (
+            <span class="text-[11px] text-[var(--color-faint)]">
+              {p.completedFocus} focus session{p.completedFocus === 1 ? "" : "s"} done
+            </span>
+          )}
+
+          <div class="flex items-center gap-2">
+            <button
+              onClick={pomodoroReset}
+              title="Reset phase"
+              class="grid h-9 w-9 place-items-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+            >
+              <RotateIcon width={16} height={16} />
+            </button>
+            <button
+              onClick={p.running ? pomodoroPause : pomodoroStart}
+              title={p.running ? "Pause" : "Start"}
+              class="grid h-11 w-11 place-items-center rounded-full bg-[var(--color-accent)] text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+            >
+              {p.running ? (
+                <PauseIcon width={20} height={20} />
+              ) : (
+                <PlayIcon width={20} height={20} />
+              )}
+            </button>
+            <button
+              onClick={pomodoroNext}
+              title="Skip to next phase"
+              class="grid h-9 w-9 place-items-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+            >
+              <SkipIcon width={16} height={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Active task stopwatch */}
+      {activeTimer && (
+        <div class="flex items-center gap-3 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
+          <span class="relative flex h-2.5 w-2.5 shrink-0">
+            <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--color-danger)] opacity-70" />
+            <span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--color-danger)]" />
+          </span>
+          <button
+            onClick={() => select(activeTimer.taskId)}
+            class="min-w-0 flex-1 text-left"
+            title="Open task"
+          >
+            <p class="truncate text-sm text-[var(--color-text)]">{activeTimer.title}</p>
+            <p class="font-mono text-xs tabular-nums text-[var(--color-muted)]">
+              {formatDuration(activeElapsed)}
+            </p>
+          </button>
+          <button
+            onClick={stopTaskTimer}
+            title="Stop tracking"
+            class="grid h-9 w-9 shrink-0 place-items-center rounded-full text-[var(--color-danger)] transition-colors hover:bg-[var(--color-surface-2)]"
+          >
+            <StopIcon width={18} height={18} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -159,6 +159,75 @@ export const SearchIcon = (p: P) => (
   </svg>
 );
 
+export const SettingsIcon = (p: P) => (
+  <svg {...base(p)}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
+export const RepeatIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="m17 2 4 4-4 4" />
+    <path d="M3 11v-1a4 4 0 0 1 4-4h14" />
+    <path d="m7 22-4-4 4-4" />
+    <path d="M21 13v1a4 4 0 0 1-4 4H3" />
+  </svg>
+);
+
+export const ExpandIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+  </svg>
+);
+
+export const TimerIcon = (p: P) => (
+  <svg {...base(p)}>
+    <circle cx="12" cy="13" r="8" />
+    <path d="M12 9v4l2 2M9 2h6M12 5V2" />
+  </svg>
+);
+
+export const PlayIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M6 4.5v15l13-7.5-13-7.5z" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+export const PauseIcon = (p: P) => (
+  <svg {...base(p)}>
+    <rect x="6" y="5" width="4" height="14" rx="1" fill="currentColor" stroke="none" />
+    <rect x="14" y="5" width="4" height="14" rx="1" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+export const StopIcon = (p: P) => (
+  <svg {...base(p)}>
+    <rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+export const SkipIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M5 4.5v15l11-7.5-11-7.5z" fill="currentColor" stroke="none" />
+    <path d="M19 5v14" />
+  </svg>
+);
+
+export const RotateIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+    <path d="M3 3v5h5" />
+  </svg>
+);
+
+export const PowerIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M12 2v10" />
+    <path d="M18.4 6.6a9 9 0 1 1-12.77.04" />
+  </svg>
+);
+
 /** The todofy brand mark — a rounded accent square with a check. */
 export const Logo = ({ size = 28 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/QuickAdd.tsx
+++ b/src/components/QuickAdd.tsx
@@ -9,10 +9,12 @@ import {
   today,
 } from "../lib/dates";
 import { parseQuickAdd } from "../lib/nlp";
-import type { NewTask, ViewId } from "../types";
-import { BellIcon, CalendarIcon, FlagIcon, PlusIcon } from "./Icons";
+import { repeatLabel } from "../lib/repeat";
+import type { NewTask, RepeatRule, ViewId } from "../types";
+import { BellIcon, CalendarIcon, FlagIcon, PlusIcon, RepeatIcon } from "./Icons";
 import { DatePicker } from "./DatePicker";
 import { PriorityPicker } from "./PriorityPicker";
+import { RepeatPicker } from "./RepeatPicker";
 
 const PRIORITY_COLOR: Record<number, string> = {
   1: "var(--color-prio-1)",
@@ -34,6 +36,7 @@ export function QuickAdd() {
   const [due, setDue] = useState(() => defaultDue(view));
   const [time, setTime] = useState<string | null>(null);
   const [priority, setPriority] = useState(4);
+  const [repeat, setRepeat] = useState<RepeatRule | null>(null);
   const [focused, setFocused] = useState(false);
 
   // When you switch views, pre-fill the date so the task shows up there.
@@ -42,7 +45,11 @@ export function QuickAdd() {
   // Live natural-language parse for the preview chips ("friday 5pm", "#home"…).
   const parsed = useMemo(() => parseQuickAdd(title, labels), [title, labels]);
   const hasChips =
-    !!parsed.dueDate || !!parsed.time || parsed.priority !== null || parsed.labelNames.length > 0;
+    !!parsed.dueDate ||
+    !!parsed.time ||
+    parsed.priority !== null ||
+    parsed.repeat !== null ||
+    parsed.labelNames.length > 0;
 
   const submit = async (e: Event) => {
     e.preventDefault();
@@ -51,14 +58,16 @@ export function QuickAdd() {
     if (!finalTitle) return;
 
     const finalTime = parsed.time ?? time;
+    const finalRepeat = parsed.repeat ?? repeat;
     const dateFromInput = parsed.dueDate ?? due;
-    // A time needs a date to live on — default to today.
-    const finalDue = dateFromInput || (finalTime ? today() : "");
+    // A time or a recurrence needs a date to anchor to — default to today.
+    const finalDue = dateFromInput || (finalTime || finalRepeat ? today() : "");
 
     const task: NewTask = { title: finalTitle, priority: parsed.priority ?? priority };
     if (finalDue) task.dueDate = finalDue;
     // A time turns into a reminder the scheduler will notify on.
     if (finalDue && finalTime) task.remindAt = combineDateTime(finalDue, finalTime);
+    if (finalRepeat) task.repeat = finalRepeat;
 
     const labelIds = new Set(parsed.labelIds);
     if (view.kind === "label") labelIds.add(view.labelId);
@@ -69,6 +78,7 @@ export function QuickAdd() {
     setDue(defaultDue(view));
     setTime(null);
     setPriority(4);
+    setRepeat(null);
   };
 
   return (
@@ -90,6 +100,7 @@ export function QuickAdd() {
           class="flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--color-faint)]"
         />
         <PriorityPicker value={priority} onChange={setPriority} />
+        <RepeatPicker value={repeat} onChange={setRepeat} />
         <DatePicker
           value={due || null}
           onChange={(v) => setDue(v ?? "")}
@@ -123,6 +134,12 @@ export function QuickAdd() {
             <Chip>
               <BellIcon width={11} height={11} />
               {formatTime(parsed.time)}
+            </Chip>
+          )}
+          {parsed.repeat && (
+            <Chip>
+              <RepeatIcon width={11} height={11} />
+              {repeatLabel(parsed.repeat)}
             </Chip>
           )}
           {parsed.labelNames.map((name) => {

--- a/src/components/QuickCapture.tsx
+++ b/src/components/QuickCapture.tsx
@@ -4,9 +4,10 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { emit } from "@tauri-apps/api/event";
 import { api } from "../lib/api";
 import { parseQuickAdd } from "../lib/nlp";
+import { repeatLabel } from "../lib/repeat";
 import { combineDateTime, formatDue, formatTime, today } from "../lib/dates";
 import type { Label, NewTask } from "../types";
-import { BellIcon, CalendarIcon, FlagIcon, Logo } from "./Icons";
+import { BellIcon, CalendarIcon, FlagIcon, Logo, RepeatIcon } from "./Icons";
 
 const PRIORITY_COLOR: Record<number, string> = {
   1: "var(--color-prio-1)",
@@ -29,7 +30,11 @@ export function QuickCapture() {
 
   const parsed = useMemo(() => parseQuickAdd(title, labels), [title, labels]);
   const hasChips =
-    !!parsed.dueDate || !!parsed.time || parsed.priority !== null || parsed.labelNames.length > 0;
+    !!parsed.dueDate ||
+    !!parsed.time ||
+    parsed.priority !== null ||
+    parsed.repeat !== null ||
+    parsed.labelNames.length > 0;
 
   const focusInput = () => requestAnimationFrame(() => inputRef.current?.focus());
 
@@ -44,12 +49,13 @@ export function QuickCapture() {
     if (!finalTitle) return;
 
     const finalTime = parsed.time;
-    // A time needs a date to live on — default to today.
-    const finalDue = parsed.dueDate || (finalTime ? today() : null);
+    // A time or a recurrence needs a date to anchor to — default to today.
+    const finalDue = parsed.dueDate || (finalTime || parsed.repeat ? today() : null);
 
     const task: NewTask = { title: finalTitle, priority: parsed.priority ?? 4 };
     if (finalDue) task.dueDate = finalDue;
     if (finalDue && finalTime) task.remindAt = combineDateTime(finalDue, finalTime);
+    if (parsed.repeat) task.repeat = parsed.repeat;
     if (parsed.labelIds.length) task.labelIds = parsed.labelIds;
 
     try {
@@ -132,6 +138,12 @@ export function QuickCapture() {
               <Chip>
                 <BellIcon width={11} height={11} />
                 {formatTime(parsed.time)}
+              </Chip>
+            )}
+            {parsed.repeat && (
+              <Chip>
+                <RepeatIcon width={11} height={11} />
+                {repeatLabel(parsed.repeat)}
               </Chip>
             )}
             {parsed.labelNames.map((name) => {

--- a/src/components/ReminderToasts.tsx
+++ b/src/components/ReminderToasts.tsx
@@ -1,9 +1,8 @@
 import { useStore } from "../store";
-import { snoozeFrom } from "../lib/dates";
 import { BellIcon, CloseIcon } from "./Icons";
 
 export function ReminderToasts() {
-  const { reminders, dismissReminder, select, patchTask } = useStore();
+  const { reminders, dismissReminder, select, snoozeTask } = useStore();
   if (reminders.length === 0) return null;
 
   return (
@@ -33,7 +32,7 @@ export function ReminderToasts() {
               </button>
               <button
                 onClick={() => {
-                  patchTask({ id: r.id, remindAt: snoozeFrom(10) });
+                  snoozeTask(r.id, 10);
                   dismissReminder(r.id);
                 }}
                 class="rounded-md bg-[var(--color-surface-2)] px-2.5 py-1 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)]"

--- a/src/components/RepeatPicker.tsx
+++ b/src/components/RepeatPicker.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import type { RepeatRule } from "../types";
+import { REPEAT_OPTIONS, repeatLabel } from "../lib/repeat";
+import { RepeatIcon } from "./Icons";
+
+interface Props {
+  value: RepeatRule | null;
+  onChange: (value: RepeatRule | null) => void;
+  /** Show the current rule's label next to the icon (used in compact rows). */
+  showLabel?: boolean;
+}
+
+/** Themed recurrence dropdown — a native <select> popup can't be styled. */
+export function RepeatPicker({ value, onChange, showLabel = false }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  return (
+    <div ref={ref} class="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Repeat"
+        class={`flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs transition-colors hover:bg-[var(--color-surface-2)] ${
+          value ? "text-[var(--color-accent)]" : "text-[var(--color-muted)]"
+        }`}
+      >
+        <RepeatIcon width={14} height={14} />
+        {showLabel && <span>{repeatLabel(value)}</span>}
+      </button>
+
+      {open && (
+        <div class="absolute right-0 z-50 mt-1 w-44 animate-fade-rise rounded-lg border border-[var(--color-border-strong)] bg-[var(--color-elevated)] p-1 shadow-xl shadow-black/40">
+          {REPEAT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value ?? "none"}
+              type="button"
+              onClick={() => {
+                onChange(opt.value);
+                setOpen(false);
+              }}
+              class={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-[var(--color-surface-2)] ${
+                opt.value === value
+                  ? "text-[var(--color-text)]"
+                  : "text-[var(--color-muted)]"
+              }`}
+            >
+              {opt.label}
+              {opt.value === value && (
+                <span class="ml-auto text-[var(--color-accent)]">✓</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,0 +1,239 @@
+import type { ComponentChildren } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import { getVersion } from "@tauri-apps/api/app";
+import { api } from "../lib/api";
+import { useStore } from "../store";
+import { MoonIcon, PowerIcon, SunIcon } from "./Icons";
+
+type StartupMode = "window" | "tray";
+
+export function SettingsView() {
+  const { theme, toggleTheme } = useStore();
+  const [autostart, setAutostart] = useState(false);
+  const [mode, setMode] = useState<StartupMode>("window");
+  const [version, setVersion] = useState("");
+  const [ready, setReady] = useState(false);
+
+  // Load current startup preferences from the backend.
+  useEffect(() => {
+    (async () => {
+      const [enabled, storedMode] = await Promise.all([
+        api.getAutostart().catch(() => false),
+        api.getSetting("startup_mode").catch(() => null),
+      ]);
+      setAutostart(enabled);
+      if (storedMode === "tray" || storedMode === "window") setMode(storedMode);
+      setReady(true);
+    })();
+    getVersion().then(setVersion).catch(() => {});
+  }, []);
+
+  const toggleAutostart = async () => {
+    const next = !autostart;
+    setAutostart(next); // optimistic
+    try {
+      await api.setAutostart(next);
+    } catch {
+      setAutostart(!next); // revert on failure
+    }
+  };
+
+  const chooseMode = async (next: StartupMode) => {
+    setMode(next);
+    try {
+      await api.setSetting("startup_mode", next);
+    } catch {
+      /* best-effort; the current selection stays shown */
+    }
+  };
+
+  return (
+    <main class="flex flex-1 flex-col overflow-hidden bg-[var(--color-bg)]">
+      <header class="shrink-0 px-8 pt-8 pb-4">
+        <h2 class="text-2xl font-semibold tracking-tight">Settings</h2>
+        <p class="mt-0.5 text-sm text-[var(--color-muted)]">
+          Startup, appearance, and about
+        </p>
+      </header>
+
+      <div class="mx-auto w-full max-w-2xl flex-1 overflow-y-auto px-8 pt-2 pb-8">
+        {/* Startup */}
+        <Section title="Startup">
+          <Row
+            icon={<PowerIcon width={18} height={18} />}
+            title="Run todofy on startup"
+            desc="Launch automatically when you sign in to your computer."
+          >
+            <Switch checked={autostart} onChange={toggleAutostart} disabled={!ready} />
+          </Row>
+
+          {autostart && (
+            <div class="animate-fade-rise border-t border-[var(--color-border)] px-4 py-3.5">
+              <p class="mb-2.5 text-xs font-medium text-[var(--color-muted)]">
+                When todofy starts at login
+              </p>
+              <div class="flex flex-col gap-2">
+                <ModeOption
+                  active={mode === "window"}
+                  onSelect={() => chooseMode("window")}
+                  title="Open the window"
+                  desc="Start with the todofy window visible."
+                />
+                <ModeOption
+                  active={mode === "tray"}
+                  onSelect={() => chooseMode("tray")}
+                  title="Start in the tray"
+                  desc="Run quietly in the system tray — open it from the tray icon or Ctrl+Alt+A."
+                />
+              </div>
+            </div>
+          )}
+        </Section>
+
+        {/* Appearance */}
+        <Section title="Appearance">
+          <Row
+            icon={
+              theme === "dark" ? (
+                <MoonIcon width={18} height={18} />
+              ) : (
+                <SunIcon width={18} height={18} />
+              )
+            }
+            title="Theme"
+            desc={theme === "dark" ? "Dark mode is on." : "Light mode is on."}
+          >
+            <button
+              onClick={toggleTheme}
+              class="rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+            >
+              Switch to {theme === "dark" ? "light" : "dark"}
+            </button>
+          </Row>
+        </Section>
+
+        {/* About */}
+        <Section title="About">
+          <Row title="Version" desc="You're running the latest installed build.">
+            <span class="rounded-full bg-[var(--color-surface-2)] px-2 py-0.5 text-xs font-medium text-[var(--color-muted)]">
+              {version ? `v${version}` : "—"}
+            </span>
+          </Row>
+        </Section>
+      </div>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <section class="mb-6">
+      <h3 class="mb-2 px-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+        {title}
+      </h3>
+      <div class="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Row({
+  icon,
+  title,
+  desc,
+  children,
+}: {
+  icon?: ComponentChildren;
+  title: string;
+  desc?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <div class="flex items-center gap-3 px-4 py-3.5">
+      {icon && (
+        <span class="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-[var(--color-surface-2)] text-[var(--color-muted)]">
+          {icon}
+        </span>
+      )}
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-medium text-[var(--color-text)]">{title}</p>
+        {desc && <p class="mt-0.5 text-xs text-[var(--color-muted)]">{desc}</p>}
+      </div>
+      <div class="shrink-0">{children}</div>
+    </div>
+  );
+}
+
+function Switch({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={onChange}
+      class={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
+        checked ? "bg-[var(--color-accent)]" : "bg-[var(--color-surface-2)]"
+      }`}
+    >
+      <span
+        class={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+function ModeOption({
+  active,
+  onSelect,
+  title,
+  desc,
+}: {
+  active: boolean;
+  onSelect: () => void;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      class={`flex items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+        active
+          ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)]"
+          : "border-[var(--color-border)] hover:bg-[var(--color-surface-2)]"
+      }`}
+    >
+      <span
+        class={`mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded-full border-2 transition-colors ${
+          active
+            ? "border-[var(--color-accent)]"
+            : "border-[var(--color-border-strong)]"
+        }`}
+      >
+        {active && (
+          <span class="h-2 w-2 rounded-full bg-[var(--color-accent)]" />
+        )}
+      </span>
+      <div class="min-w-0">
+        <p class="text-sm font-medium text-[var(--color-text)]">{title}</p>
+        <p class="mt-0.5 text-xs text-[var(--color-muted)]">{desc}</p>
+      </div>
+    </button>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,8 +9,8 @@ import {
   PinIcon,
   CheckCircleIcon,
   LabelIcon,
-  SunIcon,
-  MoonIcon,
+  SettingsIcon,
+  TimerIcon,
   Logo,
 } from "./Icons";
 
@@ -30,7 +30,7 @@ function sameView(a: ViewId, b: ViewId): boolean {
 }
 
 export function Sidebar() {
-  const { tasks, labels, view, setView, theme, toggleTheme, sidebarCollapsed } = useStore();
+  const { tasks, labels, view, setView, sidebarCollapsed, toggleFocus } = useStore();
   const [version, setVersion] = useState("");
 
   useEffect(() => {
@@ -63,11 +63,23 @@ export function Sidebar() {
         })}
 
         <button
-          onClick={toggleTheme}
-          title={theme === "dark" ? "Light mode" : "Dark mode"}
+          onClick={toggleFocus}
+          title="Focus timer"
           class="mt-auto grid h-9 w-9 place-items-center rounded-lg text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
         >
-          {theme === "dark" ? <SunIcon width={18} height={18} /> : <MoonIcon width={18} height={18} />}
+          <TimerIcon width={18} height={18} />
+        </button>
+
+        <button
+          onClick={() => setView({ kind: "settings" })}
+          title="Settings"
+          class={`grid h-9 w-9 place-items-center rounded-lg transition-colors ${
+            sameView(view, { kind: "settings" })
+              ? "bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+              : "text-[var(--color-muted)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+          }`}
+        >
+          <SettingsIcon width={18} height={18} />
         </button>
       </aside>
     );
@@ -117,17 +129,28 @@ export function Sidebar() {
         })}
       </nav>
 
-      <div class="mt-auto border-t border-[var(--color-border)] pt-3">
+      <div class="mt-auto flex flex-col gap-0.5 border-t border-[var(--color-border)] pt-3">
         <button
-          onClick={toggleTheme}
+          onClick={toggleFocus}
           class="flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-sm text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
         >
-          {theme === "dark" ? (
-            <SunIcon width={18} height={18} />
-          ) : (
-            <MoonIcon width={18} height={18} />
-          )}
-          {theme === "dark" ? "Light mode" : "Dark mode"}
+          <TimerIcon width={18} height={18} />
+          Focus timer
+        </button>
+        <button
+          onClick={() => setView({ kind: "settings" })}
+          class={`flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-sm transition-colors ${
+            sameView(view, { kind: "settings" })
+              ? "bg-[var(--color-accent-soft)] text-[var(--color-text)]"
+              : "text-[var(--color-muted)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+          }`}
+        >
+          <SettingsIcon
+            width={18}
+            height={18}
+            class={sameView(view, { kind: "settings" }) ? "text-[var(--color-accent)]" : ""}
+          />
+          Settings
         </button>
       </div>
     </aside>

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,7 +1,8 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { useStore } from "../store";
-import { combineDateTime, snoozeFrom, timeOf, toLocalDate, today } from "../lib/dates";
+import { combineDateTime, timeOf, today } from "../lib/dates";
+import type { RepeatRule } from "../types";
 import {
   CalendarIcon,
   CheckIcon,
@@ -9,9 +10,15 @@ import {
   FlagIcon,
   NoteIcon,
   PinIcon,
+  PlayIcon,
+  RepeatIcon,
+  StopIcon,
+  TimerIcon,
   TrashIcon,
 } from "./Icons";
 import { DatePicker } from "./DatePicker";
+import { RepeatPicker } from "./RepeatPicker";
+import { formatDuration } from "../lib/duration";
 
 const PRIORITIES: { value: 1 | 2 | 3 | 4; label: string; color: string }[] = [
   { value: 1, label: "P1", color: "var(--color-prio-1)" },
@@ -29,7 +36,11 @@ export function TaskDetail() {
     patchTask,
     removeTask,
     toggleTask,
+    snoozeTask,
     requestConfirm,
+    activeTimer,
+    startTaskTimer,
+    stopTaskTimer,
   } = useStore();
   const task = tasks.find((t) => t.id === selectedId);
 
@@ -58,6 +69,7 @@ export function TaskDetail() {
 
   if (!task) return null;
   const done = task.status === "done";
+  const tracking = activeTimer?.taskId === task.id;
 
   const saveTitle = () => {
     const t = title.trim();
@@ -89,6 +101,13 @@ export function TaskDetail() {
       remindAt: t ? combineDateTime(base, t) : null,
     });
   };
+  // A recurrence needs a due date to advance from; anchor to today if unset.
+  const onRepeat = (rule: RepeatRule | null) =>
+    patchTask(
+      rule && !task.dueDate
+        ? { id: task.id, repeat: rule, dueDate: today() }
+        : { id: task.id, repeat: rule },
+    );
 
   return (
     <aside class="absolute inset-y-0 right-0 z-40 flex w-[340px] animate-slide-left flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] shadow-xl shadow-black/20">
@@ -185,15 +204,13 @@ export function TaskDetail() {
             time={timeOf(task.remindAt)}
             onTimeChange={onTime}
             reminderAt={task.remindAt}
-            onSnooze={(min) => {
-              const iso = snoozeFrom(min);
-              patchTask({
-                id: task.id,
-                dueDate: toLocalDate(new Date(iso)),
-                remindAt: iso,
-              });
-            }}
+            onSnooze={(min) => snoozeTask(task.id, min)}
           />
+        </Field>
+
+        {/* Repeat */}
+        <Field icon={<RepeatIcon width={16} height={16} />} label="Repeat">
+          <RepeatPicker value={task.repeat} onChange={onRepeat} showLabel />
         </Field>
 
         {/* Priority */}
@@ -216,6 +233,32 @@ export function TaskDetail() {
                 </button>
               );
             })}
+          </div>
+        </Field>
+
+        {/* Focus time */}
+        <Field icon={<TimerIcon width={16} height={16} />} label="Focus">
+          <div class="flex items-center gap-2">
+            <button
+              onClick={() => (tracking ? stopTaskTimer() : startTaskTimer(task.id))}
+              class={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                tracking
+                  ? "bg-[var(--color-danger)] text-white"
+                  : "bg-[var(--color-surface-2)] text-[var(--color-muted)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              {tracking ? (
+                <StopIcon width={12} height={12} />
+              ) : (
+                <PlayIcon width={12} height={12} />
+              )}
+              {tracking ? "Stop" : "Start"}
+            </button>
+            <span class="text-xs text-[var(--color-faint)]">
+              {task.trackedSeconds > 0
+                ? `${formatDuration(task.trackedSeconds)} focused`
+                : "Not tracked yet"}
+            </span>
           </div>
         </Field>
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -2,8 +2,21 @@ import type { JSX } from "preact";
 import { useStore } from "../store";
 import { formatDue } from "../lib/dates";
 import type { Task } from "../types";
-import { BellIcon, CheckIcon, FlagIcon, GripIcon, PinIcon, TrashIcon } from "./Icons";
+import {
+  BellIcon,
+  CheckIcon,
+  FlagIcon,
+  GripIcon,
+  PinIcon,
+  PlayIcon,
+  RepeatIcon,
+  StopIcon,
+  TimerIcon,
+  TrashIcon,
+} from "./Icons";
 import { formatReminder } from "../lib/dates";
+import { repeatLabel } from "../lib/repeat";
+import { formatDuration } from "../lib/duration";
 
 const PRIORITY_COLOR: Record<number, string> = {
   1: "var(--color-prio-1)",
@@ -38,12 +51,17 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
     select,
     selectedId,
     requestConfirm,
+    activeTimer,
+    startTaskTimer,
+    stopTaskTimer,
   } = useStore();
   const done = task.status === "done";
   const selected = selectedId === task.id;
   const taskLabels = labels.filter((l) => task.labelIds.includes(l.id));
   const due = task.dueDate ? formatDue(task.dueDate) : null;
   const hasReminder = !!task.remindAt;
+  const repeats = !!task.repeat;
+  const tracking = activeTimer?.taskId === task.id;
   const reorderable = !!drag?.reorderable;
 
   return (
@@ -100,7 +118,7 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
         >
           {task.title}
         </p>
-        {(due || hasReminder || task.priority < 4 || taskLabels.length > 0) && (
+        {(due || hasReminder || repeats || task.trackedSeconds > 0 || task.priority < 4 || taskLabels.length > 0) && (
           <div class="mt-1 flex flex-wrap items-center gap-2">
             {task.priority < 4 && (
               <span
@@ -126,6 +144,24 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
                 {formatReminder(task.remindAt!)}
               </span>
             )}
+            {repeats && (
+              <span
+                class="inline-flex items-center gap-1 text-xs text-[var(--color-faint)]"
+                title={`Repeats ${repeatLabel(task.repeat).toLowerCase()}`}
+              >
+                <RepeatIcon width={12} height={12} />
+                {repeatLabel(task.repeat)}
+              </span>
+            )}
+            {task.trackedSeconds > 0 && (
+              <span
+                class="inline-flex items-center gap-1 text-xs text-[var(--color-faint)]"
+                title="Time focused on this task"
+              >
+                <TimerIcon width={12} height={12} />
+                {formatDuration(task.trackedSeconds)}
+              </span>
+            )}
             {taskLabels.map((l) => (
               <span
                 key={l.id}
@@ -142,6 +178,23 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
           </div>
         )}
       </div>
+
+      {!done && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            tracking ? stopTaskTimer() : startTaskTimer(task.id);
+          }}
+          class={`mt-0.5 shrink-0 transition-opacity ${
+            tracking
+              ? "text-[var(--color-danger)] opacity-100"
+              : "text-[var(--color-faint)] opacity-0 hover:text-[var(--color-accent)] group-hover:opacity-100"
+          }`}
+          title={tracking ? "Stop tracking time" : "Start tracking time"}
+        >
+          {tracking ? <StopIcon width={14} height={14} /> : <PlayIcon width={14} height={14} />}
+        </button>
+      )}
 
       <button
         onClick={(e) => {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -5,6 +5,8 @@ import { QuickAdd } from "./QuickAdd";
 import { TaskItem } from "./TaskItem";
 import { TaskSection } from "./TaskSection";
 import { LabelsView } from "./LabelsView";
+import { SettingsView } from "./SettingsView";
+import { FocusView } from "./FocusView";
 
 function viewTitle(view: ViewId, labelName?: string): string {
   switch (view.kind) {
@@ -20,6 +22,10 @@ function viewTitle(view: ViewId, labelName?: string): string {
       return "Completed";
     case "labels":
       return "Labels";
+    case "settings":
+      return "Settings";
+    case "focus":
+      return "Focus";
     case "label":
       return labelName ?? "Label";
   }
@@ -39,6 +45,10 @@ function viewSubtitle(view: ViewId): string {
       return "Everything you've finished";
     case "labels":
       return "Manage your labels";
+    case "settings":
+      return "Startup, appearance, and about";
+    case "focus":
+      return "Pomodoro and focus history";
     case "label":
       return "Tagged tasks";
   }
@@ -47,6 +57,8 @@ function viewSubtitle(view: ViewId): string {
 export function TaskList() {
   const { tasks, labels, view, loading } = useStore();
   if (view.kind === "labels") return <LabelsView />;
+  if (view.kind === "settings") return <SettingsView />;
+  if (view.kind === "focus") return <FocusView />;
 
   const labelName =
     view.kind === "label"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Label, NewTask, Task, TaskPatch } from "../types";
+import type {
+  ActiveTimer,
+  Label,
+  NewTask,
+  Pomodoro,
+  SessionLog,
+  Task,
+  TaskPatch,
+} from "../types";
 
 export const api = {
   listTasks: () => invoke<Task[]>("list_tasks"),
@@ -17,4 +25,37 @@ export const api = {
   updateLabel: (id: number, name: string, color: string) =>
     invoke<Label>("update_label", { id, name, color }),
   deleteLabel: (id: number) => invoke<void>("delete_label", { id }),
+
+  getSetting: (key: string) => invoke<string | null>("get_setting", { key }),
+  setSetting: (key: string, value: string) =>
+    invoke<void>("set_setting", { key, value }),
+  getAutostart: () => invoke<boolean>("get_autostart"),
+  setAutostart: (enabled: boolean) =>
+    invoke<void>("set_autostart", { enabled }),
+
+  // Per-task stopwatch
+  startTimer: (id: number) => invoke<ActiveTimer | null>("start_timer", { id }),
+  stopTimer: () => invoke<void>("stop_timer"),
+  activeTimer: () => invoke<ActiveTimer | null>("active_timer"),
+  focusHistory: (limit = 200) =>
+    invoke<SessionLog[]>("focus_history", { limit }),
+
+  // Standalone Pomodoro
+  getPomodoro: () => invoke<Pomodoro>("get_pomodoro"),
+  pomodoroStart: () => invoke<Pomodoro>("pomodoro_start"),
+  pomodoroPause: () => invoke<Pomodoro>("pomodoro_pause"),
+  pomodoroReset: () => invoke<Pomodoro>("pomodoro_reset"),
+  pomodoroNext: () => invoke<Pomodoro>("pomodoro_next"),
+  setPomodoroConfig: (
+    focusMin: number,
+    shortMin: number,
+    longMin: number,
+    longEvery: number,
+  ) =>
+    invoke<Pomodoro>("set_pomodoro_config", {
+      focusMin,
+      shortMin,
+      longMin,
+      longEvery,
+    }),
 };

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,0 +1,25 @@
+/** Compact human duration, e.g. "1h 20m", "45m", "30s". */
+export function formatDuration(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  if (m > 0) return `${m}m`;
+  return `${s}s`;
+}
+
+/** m:ss clock for a countdown; negative values render as overtime "+m:ss". */
+export function clock(totalSeconds: number): string {
+  const over = totalSeconds < 0;
+  const s = Math.abs(Math.floor(totalSeconds));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${over ? "+" : ""}${m}:${String(sec).padStart(2, "0")}`;
+}
+
+/** Whole seconds between an ISO instant and now (never negative). */
+export function secondsSince(iso: string): number {
+  const start = Date.parse(iso);
+  if (Number.isNaN(start)) return 0;
+  return Math.max(0, Math.floor((Date.now() - start) / 1000));
+}

--- a/src/lib/nlp.ts
+++ b/src/lib/nlp.ts
@@ -1,5 +1,5 @@
 import * as chrono from "chrono-node";
-import type { Label } from "../types";
+import type { Label, RepeatRule } from "../types";
 import { toLocalDate } from "./dates";
 
 export interface ParsedQuickAdd {
@@ -8,9 +8,22 @@ export interface ParsedQuickAdd {
   dueDate: string | null; // YYYY-MM-DD
   time: string | null; // HH:mm, only when a clock time was stated
   priority: number | null; // 1..4
+  repeat: RepeatRule | null;
   labelIds: number[];
   labelNames: string[];
 }
+
+/**
+ * Recurrence phrases, most specific first so "every weekday" wins over the
+ * "every week" prefix. The matched token is stripped from the title.
+ */
+const REPEAT_PATTERNS: { rule: RepeatRule; re: RegExp }[] = [
+  { rule: "weekdays", re: /(^|\s)(every\s?weekdays?|weekdays)(?=\s|$)/i },
+  { rule: "daily", re: /(^|\s)(every\s?day|everyday|daily)(?=\s|$)/i },
+  { rule: "weekly", re: /(^|\s)(every\s?week|weekly)(?=\s|$)/i },
+  { rule: "monthly", re: /(^|\s)(every\s?month|monthly)(?=\s|$)/i },
+  { rule: "yearly", re: /(^|\s)(every\s?year|yearly|annually)(?=\s|$)/i },
+];
 
 /** Priority written as `p1`..`p4` or `!1`..`!4`, as a standalone token. */
 const PRIORITY_RE = /(^|\s)(?:p([1-4])|!([1-4]))(?=\s|$)/i;
@@ -36,6 +49,7 @@ function tidy(s: string): string {
 export function parseQuickAdd(input: string, labels: Label[]): ParsedQuickAdd {
   let text = input;
   let priority: number | null = null;
+  let repeat: RepeatRule | null = null;
   const labelIds: number[] = [];
   const labelNames: string[] = [];
 
@@ -44,6 +58,16 @@ export function parseQuickAdd(input: string, labels: Label[]): ParsedQuickAdd {
   if (pm) {
     priority = Number(pm[2] ?? pm[3]);
     text = text.slice(0, pm.index!) + (pm[1] ? " " : "") + text.slice(pm.index! + pm[0].length);
+  }
+
+  // Recurrence next, before chrono, so "every week" isn't read as a date.
+  for (const { rule, re } of REPEAT_PATTERNS) {
+    const m = text.match(re);
+    if (m) {
+      repeat = rule;
+      text = text.slice(0, m.index!) + (m[1] ? " " : "") + text.slice(m.index! + m[0].length);
+      break;
+    }
   }
 
   // Labels: only strip a token if it names a label that actually exists.
@@ -77,6 +101,7 @@ export function parseQuickAdd(input: string, labels: Label[]): ParsedQuickAdd {
     dueDate,
     time,
     priority,
+    repeat,
     labelIds,
     labelNames,
   };

--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -1,0 +1,24 @@
+import type { RepeatRule } from "../types";
+
+/** Selectable recurrence options, in menu order. `null` = does not repeat. */
+export const REPEAT_OPTIONS: { value: RepeatRule | null; label: string }[] = [
+  { value: null, label: "Does not repeat" },
+  { value: "daily", label: "Daily" },
+  { value: "weekdays", label: "Every weekday" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+const LABELS: Record<RepeatRule, string> = {
+  daily: "Daily",
+  weekdays: "Every weekday",
+  weekly: "Weekly",
+  monthly: "Monthly",
+  yearly: "Yearly",
+};
+
+/** Human label for a recurrence rule (short form for chips). */
+export function repeatLabel(rule: RepeatRule | null | undefined): string {
+  return rule ? LABELS[rule] : "Does not repeat";
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,12 +1,14 @@
 import { create } from "zustand";
 import { api } from "./lib/api";
-import { toLocalDate, today } from "./lib/dates";
+import { snoozeFrom, toLocalDate, today } from "./lib/dates";
 import { sectionsForView } from "./lib/grouping";
 import { applyTheme, initialTheme, type Theme } from "./lib/theme";
 import type {
   ActiveReminder,
+  ActiveTimer,
   Label,
   NewTask,
+  Pomodoro,
   Task,
   TaskPatch,
   ViewId,
@@ -31,6 +33,10 @@ interface State {
   confirm: ConfirmOptions | null;
   sidebarCollapsed: boolean;
 
+  activeTimer: ActiveTimer | null;
+  pomodoro: Pomodoro | null;
+  showFocus: boolean;
+
   load: () => Promise<void>;
   setView: (view: ViewId) => void;
   select: (id: number | null) => void;
@@ -45,11 +51,29 @@ interface State {
   patchTask: (patch: TaskPatch) => Promise<void>;
   reorderTask: (id: number, orderIndex: number) => Promise<void>;
   toggleTask: (id: number, done: boolean) => Promise<void>;
+  snoozeTask: (id: number, minutes: number) => Promise<void>;
   removeTask: (id: number) => Promise<void>;
 
   addLabel: (name: string, color: string) => Promise<Label>;
   editLabel: (id: number, name: string, color: string) => Promise<void>;
   removeLabel: (id: number) => Promise<void>;
+
+  loadTimers: () => Promise<void>;
+  onTimersChanged: () => Promise<void>;
+  toggleFocus: () => void;
+  refreshPomodoro: () => Promise<void>;
+  startTaskTimer: (id: number) => Promise<void>;
+  stopTaskTimer: () => Promise<void>;
+  pomodoroStart: () => Promise<void>;
+  pomodoroPause: () => Promise<void>;
+  pomodoroReset: () => Promise<void>;
+  pomodoroNext: () => Promise<void>;
+  setPomodoroConfig: (
+    focusMin: number,
+    shortMin: number,
+    longMin: number,
+    longEvery: number,
+  ) => Promise<void>;
 }
 
 export const useStore = create<State>((set, get) => ({
@@ -62,6 +86,10 @@ export const useStore = create<State>((set, get) => ({
   theme: initialTheme(),
   confirm: null,
   sidebarCollapsed: localStorage.getItem("todofy-sidebar") === "collapsed",
+
+  activeTimer: null,
+  pomodoro: null,
+  showFocus: false,
 
   load: async () => {
     set({ loading: true });
@@ -133,6 +161,18 @@ export const useStore = create<State>((set, get) => ({
     });
   },
 
+  // Push a task's reminder `minutes` into the future. The due date follows the
+  // reminder so a snoozed task lands in the view that matches its new time —
+  // shared by the reminder toast and the detail panel so both behave the same.
+  snoozeTask: async (id, minutes) => {
+    const iso = snoozeFrom(minutes);
+    await get().patchTask({
+      id,
+      dueDate: toLocalDate(new Date(iso)),
+      remindAt: iso,
+    });
+  },
+
   removeTask: async (id) => {
     await api.deleteTask(id);
     set({
@@ -168,6 +208,53 @@ export const useStore = create<State>((set, get) => ({
       view: view.kind === "label" && view.labelId === id ? { kind: "today" } : view,
     });
   },
+
+  // --- Focus timers ---------------------------------------------------------
+
+  loadTimers: async () => {
+    const [activeTimer, pomodoro] = await Promise.all([
+      api.activeTimer(),
+      api.getPomodoro(),
+    ]);
+    // Surface the widget if something is already running (e.g. after restart).
+    set({
+      activeTimer,
+      pomodoro,
+      showFocus: get().showFocus || !!activeTimer || pomodoro.running,
+    });
+  },
+
+  // A timer changed outside the UI (e.g. the tray menu) — re-sync everything.
+  onTimersChanged: async () => {
+    const [activeTimer, pomodoro, tasks] = await Promise.all([
+      api.activeTimer(),
+      api.getPomodoro(),
+      api.listTasks(),
+    ]);
+    set({ activeTimer, pomodoro, tasks: sortTasks(tasks) });
+  },
+
+  toggleFocus: () => set({ showFocus: !get().showFocus }),
+
+  refreshPomodoro: async () => set({ pomodoro: await api.getPomodoro() }),
+
+  // Refresh tasks (without the loading skeleton) so tracked totals stay current
+  // after a session closes.
+  startTaskTimer: async (id) => {
+    const activeTimer = await api.startTimer(id);
+    set({ activeTimer, showFocus: true, tasks: sortTasks(await api.listTasks()) });
+  },
+  stopTaskTimer: async () => {
+    await api.stopTimer();
+    set({ activeTimer: null, tasks: sortTasks(await api.listTasks()) });
+  },
+
+  pomodoroStart: async () => set({ pomodoro: await api.pomodoroStart(), showFocus: true }),
+  pomodoroPause: async () => set({ pomodoro: await api.pomodoroPause() }),
+  pomodoroReset: async () => set({ pomodoro: await api.pomodoroReset() }),
+  pomodoroNext: async () => set({ pomodoro: await api.pomodoroNext() }),
+  setPomodoroConfig: async (focusMin, shortMin, longMin, longEvery) =>
+    set({ pomodoro: await api.setPomodoroConfig(focusMin, shortMin, longMin, longEvery) }),
 }));
 
 /**
@@ -203,6 +290,8 @@ export function tasksForView(tasks: Task[], view: ViewId): Task[] {
     case "completed":
       return tasks.filter((x) => x.status === "done");
     case "labels":
+    case "settings":
+    case "focus":
       return [];
     case "label":
       return tasks.filter((x) => x.labelIds.includes(view.labelId));

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,9 @@ export interface Label {
   color: string;
 }
 
+/** How a task repeats. Completing it rolls the due date to the next occurrence. */
+export type RepeatRule = "daily" | "weekdays" | "weekly" | "monthly" | "yearly";
+
 export interface Task {
   id: number;
   title: string;
@@ -16,7 +19,42 @@ export interface Task {
   completedAt: string | null;
   orderIndex: number;
   pinned: boolean;
+  repeat: RepeatRule | null;
+  trackedSeconds: number;
   labelIds: number[];
+}
+
+/** The currently running per-task stopwatch. */
+export interface ActiveTimer {
+  taskId: number;
+  title: string;
+  startAt: string; // ISO
+}
+
+/** A completed focus session, for the history view. */
+export interface SessionLog {
+  id: number;
+  taskId: number;
+  title: string;
+  startAt: string;
+  endAt: string;
+  seconds: number;
+}
+
+export type PomodoroPhase = "focus" | "short" | "long";
+
+/** Standalone Pomodoro timer state (mirrors the backend row). */
+export interface Pomodoro {
+  phase: PomodoroPhase;
+  running: boolean;
+  startAt: string | null; // ISO; set while running
+  accumulated: number; // seconds elapsed before the running segment
+  completedFocus: number;
+  target: number; // seconds the current phase should last
+  focusMin: number;
+  shortMin: number;
+  longMin: number;
+  longEvery: number;
 }
 
 export interface NewTask {
@@ -26,6 +64,7 @@ export interface NewTask {
   remindAt?: string | null;
   priority?: number;
   labelIds?: number[];
+  repeat?: RepeatRule | null;
 }
 
 export interface TaskPatch {
@@ -37,6 +76,7 @@ export interface TaskPatch {
   priority?: number;
   labelIds?: number[];
   pinned?: boolean;
+  repeat?: RepeatRule | null;
 }
 
 /** A reminder that has fired, shown as an in-app toast. */
@@ -53,4 +93,6 @@ export type ViewId =
   | { kind: "pinned" }
   | { kind: "completed" }
   | { kind: "labels" }
+  | { kind: "settings" }
+  | { kind: "focus" }
   | { kind: "label"; labelId: number };


### PR DESCRIPTION
Release **v1.3.0**. Merging this lands the version bump on `main` and triggers the release workflow to build and publish the release (with these notes from CHANGELOG.md).

## Added
- **Focus timers** — a standalone Pomodoro and a per-task stopwatch, both backend-tracked in SQLite so they keep counting while hidden in the tray and survive a restart. Neither auto-stops: they notify and keep running.
- **Focus screen** — start the Pomodoro, tune its phase lengths, and browse focus history (Today / This week / Tracked-total, grouped by day). Opens from the floating focus widget.
- **Tray timer controls** — start/pause the Pomodoro and stop the task stopwatch from the tray menu, with a live status line and a countdown on the tray icon.
- **Recurring tasks** — Daily / Every weekday / Weekly / Monthly / Yearly; completing a repeating task rolls its due date + reminder to the next occurrence instead of finishing it. Also parsed from natural language ("water plants every week").
- **Settings screen** — with run-on-startup (open the window, or start quietly in the tray).

## Changed
- Pomodoro length settings live on the Focus screen; theme toggle moved into Settings → Appearance.
- Main window starts hidden and is revealed by the backend, so a tray-mode login launch no longer flashes a window.
- Content Security Policy enabled (was disabled).

## Fixed
- Clearing a task's date/reminder/notes was a silent no-op — a serde `Option<Option<T>>` quirk collapsed an explicit `null` into "leave unchanged". Fixed with a `double_option` deserializer.

## Verification
- `bun run build` (tsc + vite) and `cargo check` / `cargo clippy` all clean.
- Not yet runtime-verified on a live GTK session: the CSP, tray title text on specific DEs, and an end-to-end timer/history pass.