### PR TITLE
Custom notification popup + portal delivery (v1.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code local config
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.4.0 — 2026-08-19
+
+### Added
+- Custom notification popup — reminders and timer nudges can show as todofy's own borderless, always-on-top card pinned to a screen corner, above other apps, instead of an OS notification. Click it to open the task; it auto-dismisses (and pauses while hovered)
+- Notification settings — choose between the in-app popup and system notifications, and pick which screen corner the popup appears in (Settings → Notifications)
+- Reminders for date-only tasks — a task with a due date but no specific time now notifies at 9:00 AM on the due day
+
+### Changed
+- Desktop notifications are now delivered through the XDG desktop portal, which is more reliable than the classic notification interface on some Linux sessions; the previous path remains as a fallback
+- The Settings "Send test" notification uses the same delivery path as real reminders and reports how it was routed
+
 ## v1.3.0 — 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Smart lists, labels, recurring tasks, focus timers, and reminders that actually 
 - ✅ **Completed view** — every finished task, app-wide, newest first
 - 🏷️ **Labels** — create, rename, recolor (with a full custom color picker), and delete; a searchable Labels page plus per-label filtering
 - 📆 **Beautiful date & time picker** — click the month or year to jump anywhere in seconds
-- ⏰ **Reminders that reach you** — native desktop notifications fire **even when hidden in the tray**, plus in‑app toasts and one‑tap **snooze**
+- ⏰ **Reminders that reach you** — desktop notifications fire **even when hidden in the tray**, as either a system notification or todofy's own popup card pinned to a screen corner, with one‑tap **snooze**
 - 🚩 **Priorities** — P1–P4 with color‑coded flags
 - ⚙️ **Settings & run‑on‑startup** — launch todofy at login, opening the window or starting quietly in the tray
 - 🌗 **Light & dark themes** — dark by default, remembers your choice
@@ -54,18 +54,18 @@ Grab a package from the [Releases](../../releases) page, or build it yourself (s
 
 **AppImage** — portable, runs on any distro:
 ```bash
-chmod +x todofy_1.3.0_amd64.AppImage
-./todofy_1.3.0_amd64.AppImage
+chmod +x todofy_1.4.0_amd64.AppImage
+./todofy_1.4.0_amd64.AppImage
 ```
 
 **Debian / Ubuntu:**
 ```bash
-sudo dpkg -i todofy_1.3.0_amd64.deb
+sudo dpkg -i todofy_1.4.0_amd64.deb
 ```
 
 **Fedora / RHEL / openSUSE:**
 ```bash
-sudo rpm -i todofy-1.3.0-1.x86_64.rpm
+sudo rpm -i todofy-1.4.0-1.x86_64.rpm
 ```
 
 > Your tasks live at `~/.local/share/com.unifybrowse.todofy/todofy.db`.
@@ -149,6 +149,8 @@ todofy/
 │       ├── timer.rs        # focus timers (Pomodoro + per-task stopwatch)
 │       ├── settings.rs     # app settings & run-on-startup
 │       ├── scheduler.rs    # background reminders + timer nudges
+│       ├── notify.rs       # notification delivery (portal / native)
+│       ├── popup.rs        # custom corner notification window
 │       ├── tray.rs         # system tray + live timer controls
 │       └── lib.rs          # app setup
 └── app-icon.svg            # source for the app icon

--- a/notification.html
+++ b/notification.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>todofy notification</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/notification.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todofy",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4018,7 +4018,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todofy"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -4031,6 +4031,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todofy"
-version = "1.3.0"
+version = "1.4.0"
 description = "A modern to-do app for Linux"
 authors = ["Salar Zeidanlou"]
 edition = "2021"
@@ -28,4 +28,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
+# Desktop notifications via the XDG portal — more reliable than the classic
+# org.freedesktop.Notifications path on some Linux sessions. Version matches
+# what Tauri already pulls in transitively.
+zbus = "5"
 

--- a/src-tauri/capabilities/notification.json
+++ b/src-tauri/capabilities/notification.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "notification",
+  "description": "Capability for the notification popup window",
+  "windows": ["notification"],
+  "permissions": ["core:default", "core:window:allow-hide"]
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -204,7 +204,9 @@ pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
 
         if let Some(rule) = repeat.as_deref().filter(|s| !s.is_empty()) {
             if let Some(next_due) = due.as_deref().and_then(|d| recur::advance_due(d, rule)) {
-                let next_remind = remind.as_deref().and_then(|r| recur::advance_remind(r, rule));
+                let next_remind = remind
+                    .as_deref()
+                    .and_then(|r| recur::advance_remind(r, rule));
                 conn.execute(
                     "UPDATE tasks SET due_date = ?1, remind_at = ?2, notified = 0 WHERE id = ?3",
                     params![next_due, next_remind, id],

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -12,7 +12,9 @@ impl Db {
     /// the connection only briefly and leaves it in a consistent state, so the
     /// data is safe to keep using.
     pub fn conn(&self) -> MutexGuard<'_, Connection> {
-        self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -118,9 +120,15 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     // install (it's in the CREATE TABLE above), so it's guarded on its
     // own; the index is unconditional since it's needed either way.
     if !column_exists(conn, "tasks", "pinned") {
-        conn.execute("ALTER TABLE tasks ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0", [])?;
+        conn.execute(
+            "ALTER TABLE tasks ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
     }
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_pinned ON tasks(pinned)", [])?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_pinned ON tasks(pinned)",
+        [],
+    )?;
 
     // Recurring tasks: completing one rolls its due date / reminder forward to
     // the next occurrence instead of marking it done (see `recur.rs`).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 mod commands;
 mod db;
 mod models;
+mod notify;
+mod popup;
 mod quickwin;
 mod recur;
 mod scheduler;
@@ -59,8 +61,7 @@ pub fn run() {
                 .app_data_dir()
                 .expect("failed to resolve app data dir");
             std::fs::create_dir_all(&dir).ok();
-            let conn = Connection::open(dir.join("todofy.db"))
-                .expect("failed to open database");
+            let conn = Connection::open(dir.join("todofy.db")).expect("failed to open database");
             db::init(&conn).expect("failed to initialize schema");
             app.manage(Db(Mutex::new(conn)));
 
@@ -116,6 +117,9 @@ pub fn run() {
             commands::create_label,
             commands::update_label,
             commands::delete_label,
+            notify::send_test_notification,
+            popup::notify_popup_dismiss,
+            popup::notify_popup_open,
             settings::get_setting,
             settings::set_setting,
             settings::get_autostart,

--- a/src-tauri/src/notify.rs
+++ b/src-tauri/src/notify.rs
@@ -1,0 +1,93 @@
+//! Desktop notifications.
+//!
+//! We prefer the XDG desktop portal (`org.freedesktop.portal.Notification`)
+//! over the classic `org.freedesktop.Notifications` interface that
+//! `tauri-plugin-notification` uses, because the classic name can be claimed by
+//! a stray process on some sessions that accepts notifications but never shows a
+//! banner. If the portal call fails we fall back to the plugin.
+//!
+//! When the user picks the `custom` notification style we instead draw our own
+//! corner popup window (see [`crate::popup`]).
+
+use crate::db::Db;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_notification::NotificationExt;
+
+/// Show a desktop notification with `title` and `body`, routed per the user's
+/// chosen style. `task_id` lets the custom popup open the right task on click.
+/// Best-effort.
+pub fn send(app: &AppHandle, title: &str, body: &str, task_id: Option<i64>) {
+    let _ = deliver(app, title, body, task_id);
+}
+
+/// Like [`send`] but reports which path delivered it: `"popup"` (custom
+/// window), `"portal"`, or `"fallback"`. `Err` means the system paths failed.
+/// Used by the Settings test button so the user sees how it was routed.
+pub fn deliver(
+    app: &AppHandle,
+    title: &str,
+    body: &str,
+    task_id: Option<i64>,
+) -> Result<&'static str, String> {
+    let style = {
+        let db = app.state::<Db>();
+        let conn = db.conn();
+        crate::settings::notification_style(&conn)
+    };
+    if style != "native" {
+        crate::popup::show(app, title, body, task_id);
+        return Ok("popup");
+    }
+
+    match portal_send(title, body) {
+        Ok(()) => Ok("portal"),
+        Err(portal_err) => app
+            .notification()
+            .builder()
+            .title(title)
+            .body(body)
+            .show()
+            .map(|()| "fallback")
+            .map_err(|plugin_err| format!("portal: {portal_err}; plugin: {plugin_err}")),
+    }
+}
+
+/// Send a one-off test notification. Returns the delivery path on success.
+#[tauri::command]
+pub fn send_test_notification(app: AppHandle) -> Result<String, String> {
+    deliver(
+        &app,
+        "todofy test notification",
+        "If you can see this, desktop notifications are working.",
+        None,
+    )
+    .map(str::to_string)
+}
+
+/// Deliver a notification via `org.freedesktop.portal.Notification.AddNotification`.
+fn portal_send(title: &str, body: &str) -> zbus::Result<()> {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use zbus::blocking::Connection;
+    use zbus::zvariant::Value;
+
+    // A distinct id per notification so successive reminders stack instead of
+    // replacing one another (the portal treats a repeated id as an update).
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let id = format!("todofy-{}", COUNTER.fetch_add(1, Ordering::Relaxed));
+
+    let mut notification: HashMap<&str, Value> = HashMap::new();
+    notification.insert("title", Value::from(title.to_owned()));
+    notification.insert("body", Value::from(body.to_owned()));
+    notification.insert("priority", Value::from("normal"));
+
+    let conn = Connection::session()?;
+    conn.call_method(
+        Some("org.freedesktop.portal.Desktop"),
+        "/org/freedesktop/portal/desktop",
+        Some("org.freedesktop.portal.Notification"),
+        "AddNotification",
+        &(id.as_str(), notification),
+    )?;
+    Ok(())
+}

--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -1,0 +1,115 @@
+//! Custom in-app notification popup.
+//!
+//! Instead of handing reminders to the OS, we draw them ourselves in a small
+//! borderless, always-on-top, non-focusing window pinned to a screen corner
+//! (the `notification` window in `tauri.conf.json`). This works uniformly
+//! regardless of the desktop's notification daemon.
+
+use crate::db::Db;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, PhysicalPosition};
+
+/// Label of the popup window, defined in tauri.conf.json.
+pub const POPUP_LABEL: &str = "notification";
+
+/// Gap (logical px) between the popup and the screen edges.
+const MARGIN: i32 = 16;
+
+/// Payload sent to the popup webview so it can render the card.
+#[derive(Serialize, Clone)]
+struct PopupPayload {
+    /// Unique per show, so the webview resets its auto-dismiss timer.
+    nonce: u64,
+    title: String,
+    body: String,
+    /// Task to open when the user clicks the card, if any.
+    task_id: Option<i64>,
+}
+
+/// Position the popup in the configured corner, push the content to its webview,
+/// and show it without stealing focus.
+pub fn show(app: &AppHandle, title: &str, body: &str, task_id: Option<i64>) {
+    let Some(win) = app.get_webview_window(POPUP_LABEL) else {
+        return;
+    };
+
+    let corner = {
+        let db = app.state::<Db>();
+        let conn = db.conn();
+        crate::settings::notification_position(&conn)
+    };
+
+    if let Some(pos) = corner_position(app, &win, &corner) {
+        let _ = win.set_position(pos);
+    }
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NONCE: AtomicU64 = AtomicU64::new(1);
+    let payload = PopupPayload {
+        nonce: NONCE.fetch_add(1, Ordering::Relaxed),
+        title: title.to_owned(),
+        body: body.to_owned(),
+        task_id,
+    };
+    let _ = win.emit_to(POPUP_LABEL, "notify-show", payload);
+    let _ = win.show();
+    let _ = win.set_always_on_top(true);
+}
+
+/// Top-left corner (physical px) for the popup on the current monitor.
+fn corner_position(
+    app: &AppHandle,
+    win: &tauri::WebviewWindow,
+    corner: &str,
+) -> Option<PhysicalPosition<i32>> {
+    let monitor = win
+        .current_monitor()
+        .ok()
+        .flatten()
+        .or_else(|| app.primary_monitor().ok().flatten())?;
+
+    let scale = monitor.scale_factor();
+    let margin = (MARGIN as f64 * scale) as i32;
+
+    let mon_pos = monitor.position();
+    let mon_size = monitor.size();
+    let win_size = win.outer_size().ok()?;
+
+    let left = mon_pos.x + margin;
+    let right = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin;
+    let top = mon_pos.y + margin;
+    let bottom = mon_pos.y + mon_size.height as i32 - win_size.height as i32 - margin;
+
+    let (x, y) = match corner {
+        "top-left" => (left, top),
+        "top-right" => (right, top),
+        "bottom-left" => (left, bottom),
+        _ => (right, bottom), // bottom-right default
+    };
+    Some(PhysicalPosition::new(x, y))
+}
+
+/// Hide the popup (called by the webview when it auto-dismisses or is closed).
+#[tauri::command]
+pub fn notify_popup_dismiss(app: AppHandle) {
+    if let Some(win) = app.get_webview_window(POPUP_LABEL) {
+        let _ = win.hide();
+    }
+}
+
+/// Bring the main window forward (optionally selecting a task) and hide the
+/// popup — the action behind clicking the notification card.
+#[tauri::command]
+pub fn notify_popup_open(app: AppHandle, task_id: Option<i64>) {
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.show();
+        let _ = main.unminimize();
+        let _ = main.set_focus();
+        if let Some(id) = task_id {
+            let _ = main.emit("reminder-open", id);
+        }
+    }
+    if let Some(win) = app.get_webview_window(POPUP_LABEL) {
+        let _ = win.hide();
+    }
+}

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -1,10 +1,13 @@
 use crate::db::Db;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, NaiveDate, NaiveTime, TimeZone};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
-use tauri_plugin_notification::NotificationExt;
 
 const POLL_SECONDS: u64 = 20;
+
+/// When a task has a due date but no explicit reminder time, fire the reminder
+/// at this hour (local) on the due day, so date-only tasks still nudge.
+const DEFAULT_REMINDER_HOUR: u32 = 9;
 
 /// A reminder that is due to fire. Also the payload for the
 /// `reminder-fired` event the frontend listens for.
@@ -26,21 +29,32 @@ pub fn spawn(app: AppHandle) {
 }
 
 fn tick(app: &AppHandle) -> Result<(), String> {
+    let (notifications_enabled, custom_popup) = {
+        let db = app.state::<Db>();
+        let conn = db.conn();
+        (
+            crate::settings::desktop_notifications_enabled(&conn),
+            crate::settings::notification_style(&conn) != "native",
+        )
+    };
+
     let due = collect_due(app)?;
     for r in due {
-        // Native OS notification — fires even when the window is hidden in
-        // the tray, since this runs on a background thread.
-        let _ = app
-            .notification()
-            .builder()
-            .title(&r.title)
-            .body("⏰ Reminder · todofy")
-            .show();
-        // Let an open window surface an in-app reminder toast too.
-        let _ = app.emit("reminder-fired", r.clone());
+        if notifications_enabled {
+            // Fires even when the window is hidden in the tray, since this runs
+            // on a background thread. Routes to the custom popup or the OS per
+            // the user's setting.
+            crate::notify::send(app, &r.title, "⏰ Reminder · todofy", Some(r.id));
+        }
+        // The custom popup already is our in-app surface; only emit the toast
+        // for the main window when we're using OS notifications, to avoid a
+        // duplicate reminder showing up twice.
+        if !(notifications_enabled && custom_popup) {
+            let _ = app.emit("reminder-fired", r.clone());
+        }
     }
     // Focus timers (Pomodoro + per-task stopwatch) also need background nudges.
-    crate::timer::poll(app);
+    crate::timer::poll(app, notifications_enabled);
     Ok(())
 }
 
@@ -51,10 +65,13 @@ fn collect_due(app: &AppHandle) -> Result<Vec<DueReminder>, String> {
     let conn = db.conn();
     let now = Local::now();
 
+    // A task can fire from an explicit reminder time (`remind_at`) or, failing
+    // that, from a due date alone — treated as DEFAULT_REMINDER_HOUR on that day.
     let mut stmt = conn
         .prepare(
-            "SELECT id, title, remind_at FROM tasks
-             WHERE status = 'active' AND notified = 0 AND remind_at IS NOT NULL",
+            "SELECT id, title, remind_at, due_date FROM tasks
+             WHERE status = 'active' AND notified = 0
+               AND (remind_at IS NOT NULL OR due_date IS NOT NULL)",
         )
         .map_err(|e| e.to_string())?;
 
@@ -63,23 +80,36 @@ fn collect_due(app: &AppHandle) -> Result<Vec<DueReminder>, String> {
             Ok((
                 r.get::<_, i64>(0)?,
                 r.get::<_, String>(1)?,
-                r.get::<_, String>(2)?,
+                r.get::<_, Option<String>>(2)?,
+                r.get::<_, Option<String>>(3)?,
             ))
         })
         .map_err(|e| e.to_string())?
-        .collect::<rusqlite::Result<Vec<(i64, String, String)>>>()
+        .collect::<rusqlite::Result<Vec<(i64, String, Option<String>, Option<String>)>>>()
         .map_err(|e| e.to_string())?;
 
     let mut due = Vec::new();
-    for (id, title, remind_at) in rows {
-        let fires = DateTime::parse_from_rfc3339(&remind_at)
-            .map(|dt| dt.with_timezone(&Local) <= now)
-            .unwrap_or(false);
-        if fires {
+    for (id, title, remind_at, due_date) in rows {
+        let fires_at = reminder_instant(remind_at.as_deref(), due_date.as_deref());
+        if fires_at.map(|t| t <= now).unwrap_or(false) {
             conn.execute("UPDATE tasks SET notified = 1 WHERE id = ?1", [id])
                 .map_err(|e| e.to_string())?;
             due.push(DueReminder { id, title });
         }
     }
     Ok(due)
+}
+
+/// Resolve when a task should notify: its explicit `remind_at` if set,
+/// otherwise its `due_date` at the default reminder hour. `None` means the
+/// task has no schedulable time (or the stored value could not be parsed).
+fn reminder_instant(remind_at: Option<&str>, due_date: Option<&str>) -> Option<DateTime<Local>> {
+    if let Some(ra) = remind_at {
+        return DateTime::parse_from_rfc3339(ra)
+            .ok()
+            .map(|dt| dt.with_timezone(&Local));
+    }
+    let day = NaiveDate::parse_from_str(due_date?, "%Y-%m-%d").ok()?;
+    let time = NaiveTime::from_hms_opt(DEFAULT_REMINDER_HOUR, 0, 0)?;
+    Local.from_local_datetime(&day.and_time(time)).single()
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -23,6 +23,24 @@ fn write(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
     Ok(())
 }
 
+/// Whether native OS notifications should fire for reminders and timers.
+/// Defaults to enabled when the user has never touched the setting.
+pub fn desktop_notifications_enabled(conn: &Connection) -> bool {
+    read(conn, "desktop_notifications_enabled").as_deref() != Some("false")
+}
+
+/// How notifications are shown: `"custom"` = todofy's own corner popup window,
+/// `"native"` = the OS notification. Defaults to custom.
+pub fn notification_style(conn: &Connection) -> String {
+    read(conn, "notification_style").unwrap_or_else(|| "custom".into())
+}
+
+/// Which screen corner the custom popup appears in: one of `top-right`,
+/// `top-left`, `bottom-right`, `bottom-left`. Defaults to bottom-right.
+pub fn notification_position(conn: &Connection) -> String {
+    read(conn, "notification_position").unwrap_or_else(|| "bottom-right".into())
+}
+
 #[tauri::command]
 pub fn get_setting(db: State<Db>, key: String) -> Result<Option<String>, String> {
     Ok(read(&db.conn(), &key))

--- a/src-tauri/src/timer.rs
+++ b/src-tauri/src/timer.rs
@@ -12,7 +12,6 @@ use crate::models::{ActiveTimer, Pomodoro, SessionLog};
 use chrono::{DateTime, Local};
 use rusqlite::{params, Connection, OptionalExtension};
 use tauri::{AppHandle, Emitter, Manager, State};
-use tauri_plugin_notification::NotificationExt;
 
 fn now_iso() -> String {
     Local::now().to_rfc3339()
@@ -246,7 +245,7 @@ pub fn set_pomodoro_config(
 /// Called from the scheduler thread. Fires reminder notifications for a
 /// finished Pomodoro phase and for long-running stopwatch sessions, without
 /// stopping either timer.
-pub fn poll(app: &AppHandle) {
+pub fn poll(app: &AppHandle, notifications_enabled: bool) {
     let db = app.state::<Db>();
     let conn = db.conn();
     let mut pomodoro_changed = false;
@@ -256,7 +255,9 @@ pub fn poll(app: &AppHandle) {
         if p.running {
             let elapsed = p.accumulated + p.start_at.as_deref().map(secs_since).unwrap_or(0);
             let notified: i64 = conn
-                .query_row("SELECT notified FROM pomodoro WHERE id = 1", [], |r| r.get(0))
+                .query_row("SELECT notified FROM pomodoro WHERE id = 1", [], |r| {
+                    r.get(0)
+                })
                 .unwrap_or(0);
             if elapsed >= p.target && notified == 0 {
                 let (title, body) = if p.phase == "focus" {
@@ -264,7 +265,9 @@ pub fn poll(app: &AppHandle) {
                 } else {
                     ("Break's over", "Back to focus · todofy")
                 };
-                let _ = app.notification().builder().title(title).body(body).show();
+                if notifications_enabled {
+                    crate::notify::send(app, title, body, None);
+                }
                 let _ = conn.execute("UPDATE pomodoro SET notified = 1 WHERE id = 1", []);
                 pomodoro_changed = true;
             }
@@ -284,12 +287,14 @@ pub fn poll(app: &AppHandle) {
         for (id, title, start, notified) in rows {
             let hours = secs_since(&start) / 3600;
             if hours > notified {
-                let _ = app
-                    .notification()
-                    .builder()
-                    .title("Still tracking time")
-                    .body(format!("“{title}” — {hours}h and counting · todofy"))
-                    .show();
+                if notifications_enabled {
+                    crate::notify::send(
+                        app,
+                        "Still tracking time",
+                        &format!("“{title}” — {hours}h and counting · todofy"),
+                        None,
+                    );
+                }
                 let _ = conn.execute(
                     "UPDATE time_sessions SET notified = ?1 WHERE id = ?2",
                     params![hours, id],
@@ -340,7 +345,12 @@ pub fn tray_display(app: &AppHandle) -> (String, String, String, bool) {
 
     let task_running = active.is_some();
     let pomo_running = pomo.as_ref().map(|p| p.running).unwrap_or(false);
-    let pomo_label = if pomo_running { "Pause focus" } else { "Start focus" }.to_string();
+    let pomo_label = if pomo_running {
+        "Pause focus"
+    } else {
+        "Start focus"
+    }
+    .to_string();
 
     let mut title = String::new();
     let mut parts: Vec<String> = Vec::new();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "todofy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.unifybrowse.todofy",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -29,6 +29,21 @@
         "transparent": true,
         "alwaysOnTop": true,
         "center": true,
+        "visible": false,
+        "skipTaskbar": true,
+        "shadow": false
+      },
+      {
+        "label": "notification",
+        "title": "todofy notification",
+        "url": "notification.html",
+        "width": 400,
+        "height": 132,
+        "resizable": false,
+        "decorations": false,
+        "transparent": true,
+        "alwaysOnTop": true,
+        "focus": false,
         "visible": false,
         "skipTaskbar": true,
         "shadow": false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,10 @@ export function App() {
     const unlisten = listen<ActiveReminder>("reminder-fired", (e) => {
       pushReminder(e.payload);
     });
+    // The custom notification popup was clicked — jump to that task.
+    const unOpen = listen<number>("reminder-open", (e) => {
+      useStore.getState().select(e.payload);
+    });
     // Refresh when a task is added from the quick-add window.
     const unAdded = listen("todo-added", () => load());
     // The scheduler advanced the Pomodoro (e.g. a phase finished) — re-sync.
@@ -51,6 +55,7 @@ export function App() {
     const unTimers = listen("timers-changed", () => onTimersChanged());
     return () => {
       unlisten.then((off) => off());
+      unOpen.then((off) => off());
       unAdded.then((off) => off());
       unPomo.then((off) => off());
       unTimers.then((off) => off());

--- a/src/components/LabelsView.tsx
+++ b/src/components/LabelsView.tsx
@@ -105,7 +105,7 @@ export function LabelsView() {
                       {count} active
                     </span>
                   </button>
-                  <div class="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                  <div class="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                     <button
                       onClick={() => {
                         setAdding(false);

--- a/src/components/NotificationPopup.tsx
+++ b/src/components/NotificationPopup.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import { BellIcon, CloseIcon } from "./Icons";
+
+/** Payload pushed from the Rust `popup::show` (serde snake_case). */
+interface NotifyPayload {
+  nonce: number;
+  title: string;
+  body: string;
+  task_id: number | null;
+}
+
+/** How long a notification stays before it auto-dismisses. */
+const AUTO_DISMISS_MS = 6000;
+
+/**
+ * The corner notification popup. Lives in its own transparent, always-on-top,
+ * non-focusing Tauri window (`notification`). The backend positions the window
+ * in the chosen screen corner and emits `notify-show`; this renders the card and
+ * dismisses itself after a timeout (paused while hovered).
+ */
+export function NotificationPopup() {
+  const [note, setNote] = useState<NotifyPayload | null>(null);
+  const timer = useRef<number | undefined>(undefined);
+
+  const clearTimer = () => {
+    if (timer.current !== undefined) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+  };
+
+  const startTimer = () => {
+    clearTimer();
+    timer.current = window.setTimeout(dismiss, AUTO_DISMISS_MS);
+  };
+
+  const dismiss = () => {
+    clearTimer();
+    setNote(null);
+    invoke("notify_popup_dismiss").catch(() => {});
+  };
+
+  const open = () => {
+    clearTimer();
+    const id = note?.task_id ?? null;
+    setNote(null);
+    invoke("notify_popup_open", { taskId: id }).catch(() => {});
+  };
+
+  useEffect(() => {
+    const unlisten = listen<NotifyPayload>("notify-show", (e) => {
+      setNote(e.payload);
+      startTimer();
+    });
+    return () => {
+      unlisten.then((off) => off());
+      clearTimer();
+    };
+  }, []);
+
+  if (!note) return null;
+
+  return (
+    <div class="flex h-screen w-screen items-stretch p-2">
+      <div
+        key={note.nonce}
+        onMouseEnter={clearTimer}
+        onMouseLeave={startTimer}
+        onClick={open}
+        class="group flex w-full animate-slide-left cursor-pointer items-start gap-3 rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] p-3.5 shadow-xl shadow-black/40"
+      >
+        <span class="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+          <BellIcon width={18} height={18} />
+        </span>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-semibold text-[var(--color-text)]">
+            {note.title}
+          </p>
+          <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-muted)]">
+            {note.body}
+          </p>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            dismiss();
+          }}
+          title="Dismiss"
+          class="shrink-0 rounded-lg p-1 text-[var(--color-faint)] opacity-0 transition-opacity hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] group-hover:opacity-100"
+        >
+          <CloseIcon width={16} height={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuickCapture.tsx
+++ b/src/components/QuickCapture.tsx
@@ -81,10 +81,17 @@ export function QuickCapture() {
       api.listLabels().then(setLabels).catch(() => {});
       focusInput();
     });
-    // Dismiss when focus leaves (click-away), ignoring the transient blur
-    // that can fire right as the window is being shown.
+    // Focus the input as soon as the window actually gains OS-level focus —
+    // more reliable than a fixed delay, since `set_focus()` on the Rust side
+    // can land after this component has already mounted. Dismiss on
+    // click-away, ignoring the transient blur that can fire right as the
+    // window is being shown.
     const unFocus = win.onFocusChanged(({ payload: focused }) => {
-      if (!focused && Date.now() - shownAt.current > 200) dismiss();
+      if (focused) {
+        focusInput();
+      } else if (Date.now() - shownAt.current > 200) {
+        dismiss();
+      }
     });
 
     return () => {
@@ -113,7 +120,7 @@ export function QuickCapture() {
               }
             }}
             placeholder="Add a task…  “pay rent friday 5pm #home p1”"
-            class="min-w-0 flex-1 bg-transparent text-base outline-none placeholder:text-[var(--color-faint)]"
+            class="min-w-0 flex-1 bg-transparent text-base outline-none focus-visible:outline-none placeholder:text-[var(--color-faint)]"
           />
           <kbd class="shrink-0 rounded-md border border-[var(--color-border)] px-1.5 py-0.5 text-[10px] text-[var(--color-faint)]">
             ↵

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -3,26 +3,56 @@ import { useEffect, useState } from "preact/hooks";
 import { getVersion } from "@tauri-apps/api/app";
 import { api } from "../lib/api";
 import { useStore } from "../store";
-import { MoonIcon, PowerIcon, SunIcon } from "./Icons";
+import { BellIcon, MoonIcon, PowerIcon, SunIcon } from "./Icons";
 
 type StartupMode = "window" | "tray";
+type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+const CORNERS: { value: Corner; label: string }[] = [
+  { value: "top-left", label: "Top left" },
+  { value: "top-right", label: "Top right" },
+  { value: "bottom-left", label: "Bottom left" },
+  { value: "bottom-right", label: "Bottom right" },
+];
+
+// How the backend routed the test notification (see notify::deliver).
+const ROUTE_LABEL: Record<string, string> = {
+  popup: "the in-app popup",
+  portal: "the desktop portal",
+  fallback: "the fallback (classic) path",
+};
 
 export function SettingsView() {
   const { theme, toggleTheme } = useStore();
   const [autostart, setAutostart] = useState(false);
   const [mode, setMode] = useState<StartupMode>("window");
+  const [desktopNotifications, setDesktopNotifications] = useState(true);
+  const [notifStyle, setNotifStyle] = useState<"custom" | "native">("custom");
+  const [notifPosition, setNotifPosition] = useState<Corner>("bottom-right");
   const [version, setVersion] = useState("");
   const [ready, setReady] = useState(false);
+  const [testStatus, setTestStatus] = useState<
+    "idle" | "sending" | "sent" | "error"
+  >("idle");
+  const [testRoute, setTestRoute] = useState("");
 
   // Load current startup preferences from the backend.
   useEffect(() => {
     (async () => {
-      const [enabled, storedMode] = await Promise.all([
-        api.getAutostart().catch(() => false),
-        api.getSetting("startup_mode").catch(() => null),
-      ]);
+      const [enabled, storedMode, storedNotifications, style, position] =
+        await Promise.all([
+          api.getAutostart().catch(() => false),
+          api.getSetting("startup_mode").catch(() => null),
+          api.getSetting("desktop_notifications_enabled").catch(() => null),
+          api.getSetting("notification_style").catch(() => null),
+          api.getSetting("notification_position").catch(() => null),
+        ]);
       setAutostart(enabled);
       if (storedMode === "tray" || storedMode === "window") setMode(storedMode);
+      setDesktopNotifications(storedNotifications !== "false");
+      setNotifStyle(style === "native" ? "native" : "custom");
+      if (CORNERS.some((c) => c.value === position))
+        setNotifPosition(position as Corner);
       setReady(true);
     })();
     getVersion().then(setVersion).catch(() => {});
@@ -44,6 +74,51 @@ export function SettingsView() {
       await api.setSetting("startup_mode", next);
     } catch {
       /* best-effort; the current selection stays shown */
+    }
+  };
+
+  const toggleDesktopNotifications = async () => {
+    const next = !desktopNotifications;
+    setDesktopNotifications(next); // optimistic
+    try {
+      await api.setSetting("desktop_notifications_enabled", next ? "true" : "false");
+    } catch {
+      setDesktopNotifications(!next); // revert on failure
+    }
+  };
+
+  const chooseStyle = async (next: "custom" | "native") => {
+    const prev = notifStyle;
+    setNotifStyle(next); // optimistic
+    try {
+      await api.setSetting("notification_style", next);
+    } catch {
+      setNotifStyle(prev);
+    }
+  };
+
+  const choosePosition = async (next: Corner) => {
+    const prev = notifPosition;
+    setNotifPosition(next); // optimistic
+    try {
+      await api.setSetting("notification_position", next);
+    } catch {
+      setNotifPosition(prev);
+    }
+  };
+
+  const sendTestNotification = async () => {
+    setTestStatus("sending");
+    try {
+      // Goes through the same portal path reminders use; resolves to the
+      // route that delivered it ("portal" or "fallback").
+      const route = await api.sendTestNotification();
+      setTestRoute(route);
+      setTestStatus("sent");
+    } catch {
+      setTestStatus("error");
+    } finally {
+      setTimeout(() => setTestStatus("idle"), 5000);
     }
   };
 
@@ -88,6 +163,88 @@ export function SettingsView() {
               </div>
             </div>
           )}
+        </Section>
+
+        {/* Notifications */}
+        <Section title="Notifications">
+          <Row
+            icon={<BellIcon width={18} height={18} />}
+            title="Desktop notifications"
+            desc="Show a native system notification when a reminder or timer is due, in addition to the in-app toast."
+          >
+            <Switch
+              checked={desktopNotifications}
+              onChange={toggleDesktopNotifications}
+              disabled={!ready}
+            />
+          </Row>
+
+          {desktopNotifications && (
+            <div class="animate-fade-rise border-t border-[var(--color-border)] px-4 py-3.5">
+              <p class="mb-2.5 text-xs font-medium text-[var(--color-muted)]">
+                Notification style
+              </p>
+              <div class="flex flex-col gap-2">
+                <ModeOption
+                  active={notifStyle === "custom"}
+                  onSelect={() => chooseStyle("custom")}
+                  title="In-app popup"
+                  desc="Show todofy's own notification in a screen corner, above other apps."
+                />
+                <ModeOption
+                  active={notifStyle === "native"}
+                  onSelect={() => chooseStyle("native")}
+                  title="System notification"
+                  desc="Hand the notification to your desktop's notification centre."
+                />
+              </div>
+
+              {notifStyle === "custom" && (
+                <div class="mt-3.5 animate-fade-rise">
+                  <p class="mb-2 text-xs font-medium text-[var(--color-muted)]">
+                    Position on screen
+                  </p>
+                  <div class="grid grid-cols-2 gap-2">
+                    {CORNERS.map((c) => (
+                      <button
+                        key={c.value}
+                        onClick={() => choosePosition(c.value)}
+                        class={`rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
+                          notifPosition === c.value
+                            ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)] text-[var(--color-text)]"
+                            : "border-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+                        }`}
+                      >
+                        {c.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div class="flex items-center gap-3 border-t border-[var(--color-border)] px-4 py-3.5">
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium text-[var(--color-text)]">
+                Test notification
+              </p>
+              <p class="mt-0.5 text-xs text-[var(--color-muted)]">
+                {testStatus === "sent"
+                  ? `Sent via ${ROUTE_LABEL[testRoute] ?? "notification"} — check your screen.`
+                  : testStatus === "error"
+                    ? "Couldn't send a notification."
+                    : "Send a one-off notification to confirm your setup."}
+              </p>
+            </div>
+            <button
+              onClick={sendTestNotification}
+              disabled={testStatus === "sending"}
+              class="shrink-0 rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] disabled:opacity-50"
+            >
+              {testStatus === "sending" ? "Sending…" : "Send test"}
+            </button>
+          </div>
         </Section>
 
         {/* Appearance */}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -188,7 +188,7 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
           class={`mt-0.5 shrink-0 transition-opacity ${
             tracking
               ? "text-[var(--color-danger)] opacity-100"
-              : "text-[var(--color-faint)] opacity-0 hover:text-[var(--color-accent)] group-hover:opacity-100"
+              : "text-[var(--color-faint)] opacity-0 hover:text-[var(--color-accent)] group-hover:opacity-100 group-focus-within:opacity-100"
           }`}
           title={tracking ? "Stop tracking time" : "Start tracking time"}
         >
@@ -204,7 +204,7 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
         class={`mt-0.5 shrink-0 transition-opacity ${
           task.pinned
             ? "text-[var(--color-accent)] opacity-100"
-            : "text-[var(--color-faint)] opacity-0 hover:text-[var(--color-text)] group-hover:opacity-100"
+            : "text-[var(--color-faint)] opacity-0 hover:text-[var(--color-text)] group-hover:opacity-100 group-focus-within:opacity-100"
         }`}
         title={task.pinned ? "Unpin" : "Pin to top"}
       >
@@ -222,7 +222,7 @@ export function TaskItem({ task, drag }: { task: Task; drag?: DragProps }) {
             onConfirm: () => removeTask(task.id),
           });
         }}
-        class="mt-0.5 text-[var(--color-faint)] opacity-0 transition-opacity hover:text-[var(--color-danger)] group-hover:opacity-100"
+        class="mt-0.5 text-[var(--color-faint)] opacity-0 transition-opacity hover:text-[var(--color-danger)] group-hover:opacity-100 group-focus-within:opacity-100"
         title="Delete"
       >
         <TrashIcon width={16} height={16} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -32,6 +32,9 @@ export const api = {
   getAutostart: () => invoke<boolean>("get_autostart"),
   setAutostart: (enabled: boolean) =>
     invoke<void>("set_autostart", { enabled }),
+  // Fires a test notification through the same portal path reminders use.
+  // Resolves to the delivery route ("portal" or "fallback").
+  sendTestNotification: () => invoke<string>("send_test_notification"),
 
   // Per-task stopwatch
   startTimer: (id: number) => invoke<ActiveTimer | null>("start_timer", { id }),

--- a/src/notification.tsx
+++ b/src/notification.tsx
@@ -1,0 +1,11 @@
+import { render } from "preact";
+import { NotificationPopup } from "./components/NotificationPopup";
+import { applyTheme, initialTheme } from "./lib/theme";
+import "./styles/global.css";
+
+// Match the main window's theme; the window itself is transparent so only the
+// floating card is visible.
+applyTheme(initialTheme());
+document.body.style.background = "transparent";
+
+render(<NotificationPopup />, document.getElementById("root")!);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,7 @@
   /* Text */
   --color-text: #e6edf3;
   --color-muted: #9aa7b4;
-  --color-faint: #6b7885;
+  --color-faint: #788592;
 
   /* Brand / accent — a warm indigo, not neon */
   --color-accent: #6c7cff;
@@ -51,7 +51,7 @@
   --color-border-strong: #d0d6dd;
   --color-text: #1a2029;
   --color-muted: #5b6773;
-  --color-faint: #8a95a1;
+  --color-faint: #636f7b;
   --color-accent-soft: #eaecff;
 }
 
@@ -68,6 +68,22 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
+}
+
+/* Visible keyboard focus indicator on every interactive control, app-wide.
+   Scoped to Tailwind's `base` layer so a utility class (e.g.
+   `focus-visible:outline-none`) can still opt a specific element out. */
+@layer base {
+  button:focus-visible,
+  a:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  [tabindex]:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-md);
+  }
 }
 
 /* Thin, unobtrusive scrollbars */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(async () => ({
       input: {
         main: entry("./index.html"),
         quickadd: entry("./quickadd.html"),
+        notification: entry("./notification.html"),
       },
     },
   },


### PR DESCRIPTION
## What & why

Desktop notifications previously went through `tauri-plugin-notification`'s classic `org.freedesktop.Notifications` D-Bus path. On some Linux sessions a stray process can own that name and silently swallow notifications — they're *accepted* (the call returns an ID) but never rendered, so nothing appears on screen. This reworks notification delivery and adds an app-drawn popup that doesn't depend on the OS notification daemon at all.

## Changes

**Delivery**
- Notifications are sent through the **XDG desktop portal** (`org.freedesktop.portal.Notification`), with the plugin kept as a fallback if the portal is unavailable (`notify.rs`, `zbus`).

**Custom in-app popup**
- New borderless, always-on-top, non-focusing `notification` window pinned to a screen corner (`popup.rs`, `notification.html`, `notification.tsx`, `NotificationPopup.tsx`, `capabilities/notification.json`).
- Click the card to open the task; it auto-dismisses after a few seconds and pauses while hovered.
- When the popup is active, the duplicate in-app toast is suppressed.

**Settings**
- Choose **In-app popup** vs **System notification**, and the **screen corner** for the popup (Settings → Notifications).
- The **Send test** button uses the real delivery path and reports how it routed.

**Reminders**
- Tasks with a due date but no time now notify at **9:00 AM** on the due day (previously never fired).

**Release prep**
- Bumped to **v1.4.0** (`package.json`, `Cargo.toml`, `tauri.conf.json`), updated `CHANGELOG.md` and `README.md`, added `.claude/` to `.gitignore`.

## Reviewer notes
- Merging to `main` triggers the release workflow, which publishes **v1.4.0** (reads version from `package.json`, notes from the `## v1.4.0` CHANGELOG section).
- Default notification style is **custom popup**.
- This branch also carries pre-existing working-tree edits (`LabelsView.tsx`, `QuickCapture.tsx`, `TaskItem.tsx`, `global.css`) that predate this work.

## Verification
- `cargo build`, `cargo clippy` (clean), `cargo fmt`
- `npm run build` (tsc + vite) — all three HTML entries bundle
- Portal delivery confirmed via a real `zbus` call rendering a banner