### PR TITLE
v1.6.0 — Search & filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,52 @@
 # Changelog
 
+## v1.6.0 — 2026-08-25
+
+### Added
+
+- Search & filters — a search bar on every task view narrows the list by title and notes as you type, with filter chips for priority and labels layered on top; press `/` to jump to search, and clear everything with one click
+
+### Fixed
+
+- Focus timers no longer run forever if you forget to stop them — a task stopwatch or Pomodoro segment left running past 12 hours (e.g. overnight, or the app was closed and reopened days later) is now auto-stopped and capped at that limit. Previously an open session's start time was read straight from the database, so a forgotten timer's elapsed time could balloon indefinitely and simply killing/restarting the app did nothing to clear it
+
 ## v1.5.0 — 2026-08-22
 
 ### Added
+
 - Subtasks / checklists — break a task into steps in the detail panel, with a live progress bar; the task row shows a `done/total` badge that turns green when everything's checked off
 - Overdue rescue — a one-click "Reschedule to today" button on the Today view moves every overdue task forward at once, and overdue tasks now carry a calm red accent bar so they're easy to spot without being alarming
-- Relative due dates — dates are phrased relative to today (*"in 3 days"*, *"3 weeks ago"*, *"Tomorrow"*), falling back to a calendar date for anything more than a month out
+- Relative due dates — dates are phrased relative to today (_"in 3 days"_, _"3 weeks ago"_, _"Tomorrow"_), falling back to a calendar date for anything more than a month out
 - Completion celebration — finishing a task can play a small confetti burst, and the Today header shows a "done today" count and a day streak; the celebration is optional (Settings → Appearance) and automatically skipped when the system prefers reduced motion
 - Keyboard shortcuts cheat-sheet — press `?` anywhere (or open it from Settings → Keyboard) to see every shortcut
 - Quick-capture discoverability — empty states and a new Settings → Quick capture entry surface the global **Ctrl+Alt+A** hotkey and the `?` cheat-sheet
 - Reduced-motion support — todofy now honors the OS "reduce motion" setting, disabling entrance animations and transitions
 
 ### Changed
+
 - The task detail panel now closes when you click anywhere in the main list area, not only via the ✕ button or `Esc`
 
 ### Fixed
+
 - Drag-and-drop reordering now works reliably inside the app — the previous implementation used the browser's native drag-and-drop, which the Linux (WebKitGTK) webview handles inconsistently, so dropping a task often did nothing; it's been rebuilt on pointer events
 
 ## v1.4.0 — 2026-08-19
 
 ### Added
+
 - Custom notification popup — reminders and timer nudges can show as todofy's own borderless, always-on-top card pinned to a screen corner, above other apps, instead of an OS notification. Click it to open the task; it auto-dismisses (and pauses while hovered)
 - Notification settings — choose between the in-app popup and system notifications, and pick which screen corner the popup appears in (Settings → Notifications)
 - Reminders for date-only tasks — a task with a due date but no specific time now notifies at 9:00 AM on the due day
 
 ### Changed
+
 - Desktop notifications are now delivered through the XDG desktop portal, which is more reliable than the classic notification interface on some Linux sessions; the previous path remains as a fallback
 - The Settings "Send test" notification uses the same delivery path as real reminders and reports how it was routed
 
 ## v1.3.0 — 2026-08-16
 
 ### Added
+
 - Focus timers — two independent, backend-tracked timers that keep counting while todofy is hidden in the tray and survive a restart:
   - Pomodoro (focus / short break / long break) with Start·Pause, Reset, and Skip, plus configurable phase lengths
   - Per-task stopwatch — press play on any task to track time on it; each session is recorded and the task shows its total focused time
@@ -42,17 +58,20 @@
 - Settings screen — with run-on-startup (launch todofy at login, opening the window or starting quietly in the tray)
 
 ### Changed
+
 - Pomodoro length settings live on the Focus screen (not the Settings screen)
 - Theme toggle moved from the sidebar into Settings → Appearance
 - The main window now starts hidden and is revealed by the backend, so a tray-mode login launch no longer flashes a window
 - Content Security Policy is now enabled (previously disabled)
 
 ### Fixed
+
 - Clearing a task's date, reminder, or notes is no longer a silent no-op — a serde `Option<Option<T>>` quirk had been collapsing an explicit `null` into "leave unchanged"
 
 ## v1.2.0 — 2026-08-13
 
 ### Added
+
 - Global quick-add (Ctrl+Alt+A) — a floating capture window that opens from anywhere, even when todofy is hidden in the tray; type a task (with natural-language parsing), press Enter, and it lands in your list without switching windows
 - Drag-and-drop reordering — grab any task and drop it into place; manual order is now the primary sort (priority is a color-coded tag, not a sort key). Order persists via a fractional index, so a reorder only rewrites the moved task
 - Natural-language quick-add — type "pay rent friday 5pm #home p1" and the date, time, priority, and labels are parsed out live, shown as preview chips, and stripped from the saved title (powered by chrono-node)
@@ -60,6 +79,7 @@
 ## v1.1.0 — 2026-08-13
 
 ### Added
+
 - Pinboard view — see all pinned tasks in one place
 - Task pinning — pin/unpin from the task row or detail panel, or press `p`; pinned tasks float to the top of their group
 - Completed view — every finished task app-wide, newest first
@@ -67,16 +87,19 @@
 - Premium color picker for labels — 16-color preset grid plus a custom hex input, styled to match the app's other popovers
 
 ### Changed
+
 - Task detail panel now opens as a floating overlay instead of pushing the task list left
 - "Mark complete" button shows a visible outlined checkmark instead of a blank circle
 - Today view no longer keeps showing a task after it was completed on a previous day
 
 ### Fixed
+
 - Database migration ordering bug that crashed startup on existing databases when adding the `pinned` column
 
 ## v1.0.0 — 2026-08-12
 
 ### Added
+
 - Smart views: Today, Upcoming, Inbox
 - Labels: create, rename, recolor, delete, filter by label
 - Quick-add tasks with due date, reminder, priority, labels

--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ Smart lists, labels, recurring tasks, focus timers, and reminders that actually 
 
 ## ✨ Features
 
-- 🗓️ **Smart views** — *Today* (with overdue rollup), *Upcoming* (grouped by date), and *Inbox*
+- 🗓️ **Smart views** — _Today_ (with overdue rollup), _Upcoming_ (grouped by date), and _Inbox_
 - ⚡ **Global quick‑add** — hit **Ctrl+Alt+A** anywhere (even with todofy tucked in the tray) for a floating capture bar; type, press Enter, and you're back to what you were doing
-- ✍️ **Natural‑language quick‑add** — type *"pay rent friday 5pm #home p1"* and the date, time, priority, and label are parsed out live and shown as chips
-- 🔁 **Recurring tasks** — repeat *daily, every weekday, weekly, monthly,* or *yearly*; completing one rolls it forward to the next occurrence instead of finishing it (also from natural language — *"water plants every week"*)
-- 🍅 **Focus timers** — a built‑in **Pomodoro** (focus / short & long breaks) *and* a **per‑task stopwatch**; both keep counting while hidden in the tray and survive a restart, and never auto‑stop — they nudge you instead
+- ✍️ **Natural‑language quick‑add** — type _"pay rent friday 5pm #home p1"_ and the date, time, priority, and label are parsed out live and shown as chips
+- 🔁 **Recurring tasks** — repeat _daily, every weekday, weekly, monthly,_ or _yearly_; completing one rolls it forward to the next occurrence instead of finishing it (also from natural language — _"water plants every week"_)
+- 🍅 **Focus timers** — a built‑in **Pomodoro** (focus / short & long breaks) _and_ a **per‑task stopwatch**; both keep counting while hidden in the tray and survive a restart, and never auto‑stop — they nudge you instead
 - 📊 **Focus screen** — start the Pomodoro, tune phase lengths, and review your focus history (Today / This week / total, grouped by day)
 - ✋ **Drag‑and‑drop reordering** — grab any task and drop it exactly where you want; your manual order sticks
-- 📌 **Pinning** — pin any task to float it to the top of its group, with a dedicated *Pinboard* view
+- 📌 **Pinning** — pin any task to float it to the top of its group, with a dedicated _Pinboard_ view
 - ✅ **Completed view** — every finished task, app-wide, newest first
 - ☑️ **Subtasks / checklists** — break a big task into steps with a live progress bar, so it's easier to start and keep momentum
-- 🧠 **ADHD-friendly touches** — relative due dates (*"in 3 days"*), a completion streak & confetti reward (both optional and motion-safe), and a `?` shortcut cheat-sheet
+- 🔍 **Search & filters** — narrow any view by title/notes as you type, with filter chips for priority and labels; press `/` to jump to search
+- 🧠 **ADHD-friendly touches** — relative due dates (_"in 3 days"_), a completion streak & confetti reward (both optional and motion-safe), and a `?` shortcut cheat-sheet
 - 🏷️ **Labels** — create, rename, recolor (with a full custom color picker), and delete; a searchable Labels page plus per-label filtering
 - 📆 **Beautiful date & time picker** — click the month or year to jump anywhere in seconds
 - ⏰ **Reminders that reach you** — desktop notifications fire **even when hidden in the tray**, as either a system notification or todofy's own popup card pinned to a screen corner, with one‑tap **snooze**
@@ -84,37 +85,41 @@ Smart lists, labels, recurring tasks, focus timers, and reminders that actually 
 Grab a package from the [Releases](../../releases) page, or build it yourself (see below).
 
 **AppImage** — portable, runs on any distro:
+
 ```bash
-chmod +x todofy_1.5.0_amd64.AppImage
-./todofy_1.5.0_amd64.AppImage
+chmod +x todofy_1.6.0_amd64.AppImage
+./todofy_1.6.0_amd64.AppImage
 ```
 
 **Debian / Ubuntu:**
+
 ```bash
-sudo dpkg -i todofy_1.5.0_amd64.deb
+sudo dpkg -i todofy_1.6.0_amd64.deb
 ```
 
 **Fedora / RHEL / openSUSE:**
+
 ```bash
-sudo rpm -i todofy-1.5.0-1.x86_64.rpm
+sudo rpm -i todofy-1.6.0-1.x86_64.rpm
 ```
 
 > Your tasks live at `~/.local/share/com.unifybrowse.todofy/todofy.db`.
 
 ## ⌨️ Keyboard shortcuts
 
-| Key | Action |
-| --- | --- |
-| `Ctrl`+`Alt`+`A` | Open the global quick‑add bar from anywhere (works app‑wide) |
-| `n` | Focus the quick‑add bar |
-| `j` / `↓` | Move to next task |
-| `k` / `↑` | Move to previous task |
-| `e` | Edit the selected task |
-| `c` / `Enter` | Complete / uncomplete the selected task |
-| `p` | Pin / unpin the selected task |
-| `Backspace` / `Delete` | Delete the selected task |
-| `?` | Show the keyboard shortcuts cheat-sheet |
-| `Esc` | Close the detail panel / picker / cheat-sheet |
+| Key                    | Action                                                       |
+| ---------------------- | ------------------------------------------------------------ |
+| `Ctrl`+`Alt`+`A`       | Open the global quick‑add bar from anywhere (works app‑wide) |
+| `n`                    | Focus the quick‑add bar                                      |
+| `/`                    | Focus the search bar                                         |
+| `j` / `↓`              | Move to next task                                            |
+| `k` / `↑`              | Move to previous task                                        |
+| `e`                    | Edit the selected task                                       |
+| `c` / `Enter`          | Complete / uncomplete the selected task                      |
+| `p`                    | Pin / unpin the selected task                                |
+| `Backspace` / `Delete` | Delete the selected task                                     |
+| `?`                    | Show the keyboard shortcuts cheat-sheet                      |
+| `Esc`                  | Close the detail panel / picker / cheat-sheet                |
 
 ## 🛠️ Build from source
 
@@ -154,14 +159,14 @@ bunx tauri icon app-icon.svg
 
 ## 🧱 Tech stack
 
-| Layer | Choice |
-| --- | --- |
-| Shell | [Tauri 2](https://tauri.app) (Rust) |
-| UI | [Preact](https://preactjs.com) + TypeScript |
+| Layer   | Choice                                                                |
+| ------- | --------------------------------------------------------------------- |
+| Shell   | [Tauri 2](https://tauri.app) (Rust)                                   |
+| UI      | [Preact](https://preactjs.com) + TypeScript                           |
 | Styling | [Tailwind CSS 4](https://tailwindcss.com) with a custom design system |
-| State | [Zustand](https://github.com/pmndrs/zustand) |
-| Storage | SQLite via [rusqlite](https://github.com/rusqlite/rusqlite) |
-| Build | [Vite](https://vite.dev) + [Bun](https://bun.sh) |
+| State   | [Zustand](https://github.com/pmndrs/zustand)                          |
+| Storage | SQLite via [rusqlite](https://github.com/rusqlite/rusqlite)           |
+| Build   | [Vite](https://vite.dev) + [Bun](https://bun.sh)                      |
 
 ## 📁 Project structure
 
@@ -191,12 +196,12 @@ todofy/
 ## 🗺️ Roadmap
 
 - [x] Drag‑and‑drop reordering
-- [x] Natural‑language quick‑add (*"pay rent friday 5pm"*)
+- [x] Natural‑language quick‑add (_"pay rent friday 5pm"_)
 - [x] Recurring tasks
 - [x] Focus timers (Pomodoro + per‑task time tracking)
 - [x] Run on startup
 - [x] Subtasks & checklists
-- [ ] Search & filters
+- [x] Search & filters
 
 ## 🤝 Contributing
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todofy",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4018,7 +4018,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todofy"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todofy"
-version = "1.5.0"
+version = "1.6.0"
 description = "A modern to-do app for Linux"
 authors = ["Salar Zeidanlou"]
 edition = "2021"

--- a/src-tauri/src/timer.rs
+++ b/src-tauri/src/timer.rs
@@ -2,10 +2,12 @@
 //! while the window is hidden in the tray and survive a restart.
 //!
 //! * Per-task stopwatch — `time_sessions` rows; the one with a NULL `end_at`
-//!   is running. Neither timer auto-stops: `poll` only fires reminder
-//!   notifications and lets them keep running.
+//!   is running. `poll` fires reminder notifications but otherwise lets a
+//!   session run; a session left open past `MAX_SESSION_SECS` (e.g. forgotten
+//!   overnight) is auto-stopped and capped rather than left to grow forever.
 //! * Standalone Pomodoro — the single `pomodoro` row; elapsed time in the
-//!   current phase is `accumulated + (now - start_at)` while running.
+//!   current phase is `accumulated + (now - start_at)` while running, capped
+//!   the same way if left running past `MAX_SESSION_SECS`.
 
 use crate::db::Db;
 use crate::models::{ActiveTimer, Pomodoro, SessionLog};
@@ -24,9 +26,36 @@ fn secs_since(iso: &str) -> i64 {
         .unwrap_or(0)
 }
 
+/// Safety cap: nothing tracks (or counts overtime) longer than this without
+/// user interaction. Guards against a forgotten timer running for days after
+/// the app was closed and reopened — that stale `start_at` is read straight
+/// from SQLite, so a bare restart never clears it on its own.
+const MAX_SESSION_SECS: i64 = 12 * 3600;
+
 // ---------------------------------------------------------------- stopwatch
 
+/// Auto-stop any task session that's been running longer than
+/// `MAX_SESSION_SECS`, capping its recorded duration at that limit.
+fn close_stale_sessions(conn: &Connection) -> rusqlite::Result<()> {
+    let now = now_iso();
+    let mut stmt =
+        conn.prepare("SELECT id, start_at FROM time_sessions WHERE end_at IS NULL")?;
+    let rows: Vec<(i64, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    for (id, start) in rows {
+        if secs_since(&start) > MAX_SESSION_SECS {
+            conn.execute(
+                "UPDATE time_sessions SET end_at = ?1, seconds = ?2 WHERE id = ?3",
+                params![now, MAX_SESSION_SECS, id],
+            )?;
+        }
+    }
+    Ok(())
+}
+
 fn read_active(conn: &Connection) -> rusqlite::Result<Option<ActiveTimer>> {
+    close_stale_sessions(conn)?;
     conn.query_row(
         "SELECT s.task_id, t.title, s.start_at
          FROM time_sessions s JOIN tasks t ON t.id = s.task_id
@@ -125,7 +154,31 @@ fn phase_target(phase: &str, focus: i64, short: i64, long: i64) -> i64 {
     minutes * 60
 }
 
+/// Auto-pause a Pomodoro segment that's been running (including overtime)
+/// longer than `MAX_SESSION_SECS`, folding the capped duration into
+/// `accumulated` just like a normal pause.
+fn close_stale_pomodoro(conn: &Connection) -> rusqlite::Result<()> {
+    let row: Option<(i64, String)> = conn
+        .query_row(
+            "SELECT accumulated, start_at FROM pomodoro WHERE id = 1 AND running = 1 AND start_at IS NOT NULL",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?;
+    if let Some((accumulated, start_at)) = row {
+        let elapsed = accumulated + secs_since(&start_at);
+        if elapsed > MAX_SESSION_SECS {
+            conn.execute(
+                "UPDATE pomodoro SET running = 0, start_at = NULL, accumulated = ?1 WHERE id = 1",
+                params![MAX_SESSION_SECS],
+            )?;
+        }
+    }
+    Ok(())
+}
+
 fn read_pomodoro(conn: &Connection) -> rusqlite::Result<Pomodoro> {
+    close_stale_pomodoro(conn)?;
     conn.query_row(
         "SELECT phase, running, start_at, accumulated, completed_focus,
                 focus_min, short_min, long_min, long_every
@@ -249,6 +302,10 @@ pub fn poll(app: &AppHandle, notifications_enabled: bool) {
     let db = app.state::<Db>();
     let conn = db.conn();
     let mut pomodoro_changed = false;
+
+    // Enforce the runaway-timer safety cap even if nobody's looking at the UI.
+    let _ = close_stale_sessions(&conn);
+    let _ = close_stale_pomodoro(&conn);
 
     // Pomodoro phase reached its target — nudge once, keep running (overtime).
     if let Ok(p) = read_pomodoro(&conn) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "todofy",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "identifier": "com.unifybrowse.todofy",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/PriorityPicker.tsx
+++ b/src/components/PriorityPicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { FlagIcon } from "./Icons";
 
-const PRIORITIES: { value: 1 | 2 | 3 | 4; label: string; color: string }[] = [
+export const PRIORITIES: { value: 1 | 2 | 3 | 4; label: string; color: string }[] = [
   { value: 1, label: "Priority 1", color: "var(--color-prio-1)" },
   { value: 2, label: "Priority 2", color: "var(--color-prio-2)" },
   { value: 3, label: "Priority 3", color: "var(--color-prio-3)" },

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,113 @@
+import { useRef } from "preact/hooks";
+import { useStore } from "../store";
+import { CloseIcon, FlagIcon, SearchIcon } from "./Icons";
+import { PRIORITIES } from "./PriorityPicker";
+
+export function SearchBar() {
+  const {
+    labels,
+    searchQuery,
+    filterLabelIds,
+    filterPriorities,
+    setSearchQuery,
+    toggleFilterLabel,
+    toggleFilterPriority,
+    clearFilters,
+  } = useStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasFilters =
+    searchQuery.trim() !== "" ||
+    filterLabelIds.length > 0 ||
+    filterPriorities.length > 0;
+
+  return (
+    <div class="mt-4 flex flex-col gap-2">
+      <div class="relative">
+        <SearchIcon
+          width={15}
+          height={15}
+          class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-faint)]"
+        />
+        <input
+          ref={inputRef}
+          id="search-input"
+          value={searchQuery}
+          onInput={(e) => setSearchQuery(e.currentTarget.value)}
+          placeholder="Search tasks…"
+          class="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] py-2 pl-8 pr-9 text-sm outline-none focus:border-[var(--color-accent)]"
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery("");
+              inputRef.current?.focus();
+            }}
+            class="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--color-faint)] transition-colors hover:text-[var(--color-text)]"
+            title="Clear search"
+            aria-label="Clear search"
+          >
+            <CloseIcon width={14} height={14} />
+          </button>
+        )}
+      </div>
+
+      <div class="flex flex-wrap items-center gap-1.5">
+        {PRIORITIES.map((priority) => {
+          const active = filterPriorities.includes(priority.value);
+          return (
+            <button
+              key={priority.value}
+              type="button"
+              onClick={() => toggleFilterPriority(priority.value)}
+              class={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors ${
+                active
+                  ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                  : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-muted)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              <FlagIcon
+                width={12}
+                height={12}
+                style={{ color: priority.color }}
+              />
+              {priority.label}
+            </button>
+          );
+        })}
+
+        {labels.map((label) => {
+          const active = filterLabelIds.includes(label.id);
+          return (
+            <button
+              key={label.id}
+              type="button"
+              onClick={() => toggleFilterLabel(label.id)}
+              class={`inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs transition-colors ${
+                active
+                  ? "border-[var(--color-accent)] bg-[var(--color-accent-soft)] text-[var(--color-accent)]"
+                  : "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-muted)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text)]"
+              }`}
+            >
+              <span
+                class="h-2.5 w-2.5 rounded-full"
+                style={{ background: label.color }}
+              />
+              {label.name}
+            </button>
+          );
+        })}
+
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            class="ml-auto px-1 py-1 text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import { tasksForView, useStore } from "../store";
+import { applySearchAndFilters, tasksForView, useStore } from "../store";
 import { sectionsForView } from "../lib/grouping";
 import { completionStats } from "../lib/streak";
 import type { Task, ViewId } from "../types";
@@ -8,6 +8,7 @@ import { TaskSection } from "./TaskSection";
 import { LabelsView } from "./LabelsView";
 import { SettingsView } from "./SettingsView";
 import { FocusView } from "./FocusView";
+import { SearchBar } from "./SearchBar";
 
 function viewTitle(view: ViewId, labelName?: string): string {
   switch (view.kind) {
@@ -56,7 +57,17 @@ function viewSubtitle(view: ViewId): string {
 }
 
 export function TaskList() {
-  const { tasks, labels, view, loading, rescheduleOverdue } = useStore();
+  const {
+    tasks,
+    labels,
+    view,
+    loading,
+    searchQuery,
+    filterLabelIds,
+    filterPriorities,
+    clearFilters,
+    rescheduleOverdue,
+  } = useStore();
   if (view.kind === "labels") return <LabelsView />;
   if (view.kind === "settings") return <SettingsView />;
   if (view.kind === "focus") return <FocusView />;
@@ -73,9 +84,18 @@ export function TaskList() {
     (view.kind === "today" || view.kind === "completed") &&
     (stats.doneToday > 0 || stats.streak > 0);
 
-  const inView = tasksForView(tasks, view);
+  const inView = applySearchAndFilters(
+    tasksForView(tasks, view),
+    searchQuery,
+    filterLabelIds,
+    filterPriorities,
+  );
   const active = inView.filter((t) => t.status === "active");
   const done = inView.filter((t) => t.status === "done");
+  const hasFilters =
+    searchQuery.trim() !== "" ||
+    filterLabelIds.length > 0 ||
+    filterPriorities.length > 0;
   const sections = sectionsForView(isCompletedView ? inView : active, view).filter(
     (s) => s.tasks.length > 0,
   );
@@ -111,6 +131,9 @@ export function TaskList() {
         <p class="mt-0.5 text-sm text-[var(--color-muted)]">
           {viewSubtitle(view)}
         </p>
+        <div class="mx-auto w-full max-w-2xl">
+          <SearchBar />
+        </div>
       </header>
 
       {showQuickAdd && (
@@ -123,7 +146,11 @@ export function TaskList() {
         {loading ? (
           <Skeleton />
         ) : active.length === 0 && done.length === 0 ? (
-          <Empty view={view} />
+          hasFilters ? (
+            <FilteredEmpty clearFilters={clearFilters} />
+          ) : (
+            <Empty view={view} />
+          )
         ) : (
           <>
             {sections.map((section) => (
@@ -176,6 +203,23 @@ export function TaskList() {
         )}
       </div>
     </main>
+  );
+}
+
+function FilteredEmpty({ clearFilters }: { clearFilters: () => void }) {
+  return (
+    <div class="mt-16 flex flex-col items-center gap-3 text-center">
+      <p class="text-sm text-[var(--color-muted)]">
+        No tasks match your search or filters.
+      </p>
+      <button
+        type="button"
+        onClick={clearFilters}
+        class="rounded-md px-2.5 py-1.5 text-xs font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-soft)]"
+      >
+        Clear filters
+      </button>
+    </div>
   );
 }
 

--- a/src/lib/useKeyboard.ts
+++ b/src/lib/useKeyboard.ts
@@ -69,6 +69,10 @@ export function useKeyboard() {
       };
 
       switch (e.key) {
+        case "/":
+          e.preventDefault();
+          focusById("search-input");
+          break;
         case "n":
           e.preventDefault();
           focusById("quick-add-input");

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,6 +32,9 @@ interface State {
   theme: Theme;
   confirm: ConfirmOptions | null;
   sidebarCollapsed: boolean;
+  searchQuery: string;
+  filterLabelIds: number[];
+  filterPriorities: number[];
 
   activeTimer: ActiveTimer | null;
   pomodoro: Pomodoro | null;
@@ -46,6 +49,10 @@ interface State {
   load: () => Promise<void>;
   setView: (view: ViewId) => void;
   select: (id: number | null) => void;
+  setSearchQuery: (q: string) => void;
+  toggleFilterLabel: (id: number) => void;
+  toggleFilterPriority: (p: number) => void;
+  clearFilters: () => void;
   toggleTheme: () => void;
   toggleSidebar: () => void;
   toggleShortcuts: (open?: boolean) => void;
@@ -95,6 +102,9 @@ export const useStore = create<State>((set, get) => ({
   theme: initialTheme(),
   confirm: null,
   sidebarCollapsed: localStorage.getItem("todofy-sidebar") === "collapsed",
+  searchQuery: "",
+  filterLabelIds: [],
+  filterPriorities: [],
 
   activeTimer: null,
   pomodoro: null,
@@ -115,6 +125,21 @@ export const useStore = create<State>((set, get) => ({
 
   setView: (view) => set({ view, selectedId: null }),
   select: (id) => set({ selectedId: id }),
+  setSearchQuery: (searchQuery) => set({ searchQuery }),
+  toggleFilterLabel: (id) =>
+    set({
+      filterLabelIds: get().filterLabelIds.includes(id)
+        ? get().filterLabelIds.filter((labelId) => labelId !== id)
+        : [...get().filterLabelIds, id],
+    }),
+  toggleFilterPriority: (priority) =>
+    set({
+      filterPriorities: get().filterPriorities.includes(priority)
+        ? get().filterPriorities.filter((p) => p !== priority)
+        : [...get().filterPriorities, priority],
+    }),
+  clearFilters: () =>
+    set({ searchQuery: "", filterLabelIds: [], filterPriorities: [] }),
 
   toggleTheme: () => {
     const theme: Theme = get().theme === "dark" ? "light" : "dark";
@@ -332,6 +357,29 @@ function sortTasks(tasks: Task[]): Task[] {
   );
 }
 
+export function applySearchAndFilters(
+  tasks: Task[],
+  searchQuery: string,
+  filterLabelIds: number[],
+  filterPriorities: number[],
+): Task[] {
+  const query = searchQuery.trim().toLowerCase();
+  if (!query && filterLabelIds.length === 0 && filterPriorities.length === 0) {
+    return tasks;
+  }
+
+  return tasks.filter(
+    (task) =>
+      (!query ||
+        task.title.toLowerCase().includes(query) ||
+        (task.notes ?? "").toLowerCase().includes(query)) &&
+      (filterLabelIds.length === 0 ||
+        task.labelIds.some((id) => filterLabelIds.includes(id))) &&
+      (filterPriorities.length === 0 ||
+        filterPriorities.includes(task.priority)),
+  );
+}
+
 /** Filter tasks for the active view. */
 export function tasksForView(tasks: Task[], view: ViewId): Task[] {
   const t = today();
@@ -378,7 +426,13 @@ export function navCount(tasks: Task[], view: ViewId): number {
 
 /** Task ids in on-screen order for the active view — drives keyboard nav. */
 export function visibleTaskIds(tasks: Task[], view: ViewId): number[] {
-  const inView = tasksForView(tasks, view);
+  const { searchQuery, filterLabelIds, filterPriorities } = useStore.getState();
+  const inView = applySearchAndFilters(
+    tasksForView(tasks, view),
+    searchQuery,
+    filterLabelIds,
+    filterPriorities,
+  );
   const relevant =
     view.kind === "completed" || view.kind === "pinned"
       ? inView


### PR DESCRIPTION
## Summary
- Search & filters — search bar (title + notes) plus priority and label filter chips, layered on top of any smart view; `/` focuses search, one click clears everything
- Focus timers no longer run forever if forgotten — a stopwatch/Pomodoro segment left open past 12 hours is auto-stopped and capped
- Version bump to 1.6.0 (package.json, tauri.conf.json, Cargo.toml/Cargo.lock)
- CHANGELOG.md and README.md updated for the release

## Test plan
- [x] `bun run build` (tsc + vite) passes
- [x] Manually exercised search input, priority chips, and "Clear filters" in the browser
- [x] Smoke-test the packaged app (`bun run tauri build`) before tagging the release