### PR TITLE
v1.7.0 — account sync, notification popup redesign, custom context menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Supabase connection for account sync. Copy to `.env` and fill in.
+# The publishable (anon) key is safe to ship in a client — row-level
+# security is what actually protects data.
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_ANON_KEY=sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,13 @@ dist-ssr
 
 # Claude Code local config
 .claude/
+
+# Local environment (Supabase URL/keys); see .env.example
+.env
+.env.*
+!.env.example
+
+# Agent / MCP tooling (local, not part of the app)
+.agents/
+.mcp.json
+skills-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.7.0 — 2026-08-27
+
+### Added
+
+- Account sync — sign in with an email and password (Settings → Account) to sync your tasks, labels, focus sessions, and their history across devices, backed by Supabase. It's fully optional and additive: todofy still works exactly as before with no account, entirely offline and local-first. Sign-in and sign-up happen in a polished in-app modal, with a live sync-status indicator (last synced, syncing, offline, or failed) and a manual **Sync now** button
+- Sessions are stored in your operating system's secret store (libsecret / Keychain / Credential Manager) rather than in the app's web storage, falling back gracefully where no keychain is available
+
+### Changed
+
+- Redesigned the notification popup — a cleaner card with a ringed icon and a slim auto-dismiss progress bar that pauses while you hover
+- A custom right-click menu replaces the webview's browser one (Back / Forward / Reload / Inspect Element) — a clean todofy menu with context-aware **Cut / Copy / Paste / Select all** on text fields (with shortcut hints) plus quick **New task**, **Settings**, and theme toggle actions
+
+### Fixed
+
+- The notification popup can no longer get "stuck" as an invisible, click-blocking window in a screen corner. If its content ever failed to draw (for example, the popup window loaded a beat after the reminder fired), the transparent always-on-top frame could linger and swallow clicks; it now reliably shows its content and always hides itself, with a backend safety timeout as a backstop
+
 ## v1.6.0 — 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Smart lists, labels, recurring tasks, focus timers, and reminders that actually 
 - ⌨️ **Keyboard‑first** — add, navigate, complete, and edit without touching the mouse
 - 🪟 **System tray** — closes to tray and keeps running so reminders never miss; start/pause the Pomodoro, stop the task timer, and watch the live countdown right from the tray
 - 🧭 **Collapsible sidebar** — go full or minimal
-- 💾 **Local‑first** — everything is stored in a local SQLite database; no account, no cloud, no tracking
+- ☁️ **Optional account sync** — sign in with an email and password to sync your tasks, labels, and focus history across devices (backed by Supabase, with row‑level security). Sessions are kept in your OS secret store, and the whole thing is opt‑in
+- 💾 **Local‑first** — everything is stored in a local SQLite database and works fully offline; sync is additive, and with no account there's no cloud and no tracking
 
 ## 📸 Screenshots
 
@@ -166,6 +167,7 @@ bunx tauri icon app-icon.svg
 | Styling | [Tailwind CSS 4](https://tailwindcss.com) with a custom design system |
 | State   | [Zustand](https://github.com/pmndrs/zustand)                          |
 | Storage | SQLite via [rusqlite](https://github.com/rusqlite/rusqlite)           |
+| Sync    | [Supabase](https://supabase.com) (Postgres + Auth), optional          |
 | Build   | [Vite](https://vite.dev) + [Bun](https://bun.sh)                      |
 
 ## 📁 Project structure
@@ -189,6 +191,8 @@ todofy/
 │       ├── notify.rs       # notification delivery (portal / native)
 │       ├── popup.rs        # custom corner notification window
 │       ├── tray.rs         # system tray + live timer controls
+│       ├── sync.rs         # account-sync merge (push/pull, last-write-wins)
+│       ├── secret.rs       # OS keychain access for the session
 │       └── lib.rs          # app setup
 └── app-icon.svg            # source for the app icon
 ```
@@ -202,6 +206,7 @@ todofy/
 - [x] Run on startup
 - [x] Subtasks & checklists
 - [x] Search & filters
+- [x] Optional account sync across devices
 
 ## 🤝 Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "todofy",
       "dependencies": {
+        "@supabase/supabase-js": "^2.112.4",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
@@ -191,6 +192,20 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
 
+    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
@@ -305,6 +320,8 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -378,6 +395,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todofy",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,6 +11,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.112.4",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +523,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -521,6 +566,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -542,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -555,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -687,6 +742,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +828,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1563,6 +1637,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2124,22 @@ dependencies = [
  "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -2239,6 +2357,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2380,40 @@ dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus",
+ "zbus 5.19.0",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2257,6 +2421,36 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2846,12 +3040,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2861,7 +3076,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3108,6 +3332,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.8",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3735,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3524,7 +3826,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3739,7 +4041,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3769,7 +4071,7 @@ dependencies = [
  "thiserror 2.0.20",
  "url",
  "windows",
- "zbus",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -3785,7 +4087,7 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -4018,9 +4320,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todofy"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "chrono",
+ "keyring",
  "rusqlite",
  "serde",
  "serde_json",
@@ -4031,7 +4334,8 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
- "zbus",
+ "uuid",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -4842,6 +5146,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5209,6 +5522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +5558,38 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.8",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5267,9 +5622,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.4",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.19.0",
+ "zbus_names 4.3.4",
+ "zvariant 5.14.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5282,9 +5650,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.4",
+ "zvariant 5.14.0",
+ "zvariant_utils 4.0.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5295,7 +5674,7 @@ checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.4",
- "zvariant",
+ "zvariant 5.14.0",
 ]
 
 [[package]]
@@ -5349,6 +5728,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5389,6 +5788,19 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
@@ -5398,8 +5810,21 @@ dependencies = [
  "serde",
  "winnow 1.0.4",
  "zcheapstr",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.14.0",
+ "zvariant_utils 4.0.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5412,7 +5837,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
- "zvariant_utils",
+ "zvariant_utils 4.0.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todofy"
-version = "1.6.0"
+version = "1.7.0"
 description = "A modern to-do app for Linux"
 authors = ["Salar Zeidanlou"]
 edition = "2021"
@@ -32,4 +32,16 @@ chrono = { version = "0.4", features = ["serde"] }
 # org.freedesktop.Notifications path on some Linux sessions. Version matches
 # what Tauri already pulls in transitively.
 zbus = "5"
+# UUID primary keys for syncable rows (tasks, labels, sessions). Generated
+# on-device so records can be created offline and still merge cleanly into a
+# shared cloud database without id collisions between devices.
+uuid = { version = "1", features = ["v4"] }
+# OS-native secret store for the account session (libsecret / Keychain /
+# Credential Manager), so tokens don't sit in the webview's localStorage.
+keyring = { version = "3", features = [
+    "apple-native",
+    "windows-native",
+    "sync-secret-service",
+    "crypto-rust",
+] }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::db::Db;
+use crate::db::{new_uuid, Db};
 use crate::models::{Label, NewTask, Task, TaskPatch};
 use crate::recur;
 use chrono::Local;
@@ -11,20 +11,33 @@ fn now_iso() -> String {
     Local::now().to_rfc3339()
 }
 
-fn label_ids_for(conn: &Connection, task_id: i64) -> rusqlite::Result<Vec<i64>> {
-    let mut stmt = conn.prepare("SELECT label_id FROM task_labels WHERE task_id = ?1")?;
+fn label_ids_for(conn: &Connection, task_id: &str) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT tl.label_id FROM task_labels tl
+         JOIN labels l ON l.id = tl.label_id
+         WHERE tl.task_id = ?1 AND tl.deleted_at IS NULL AND l.deleted_at IS NULL",
+    )?;
     let ids = stmt
-        .query_map([task_id], |r| r.get::<_, i64>(0))?
-        .collect::<rusqlite::Result<Vec<i64>>>()?;
+        .query_map([task_id], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
     Ok(ids)
 }
 
-fn load_task(conn: &Connection, id: i64) -> rusqlite::Result<Task> {
+fn touch_and_load(conn: &Connection, id: &str) -> rusqlite::Result<Task> {
+    conn.execute(
+        "UPDATE tasks SET updated_at = ?1 WHERE id = ?2",
+        params![now_iso(), id],
+    )?;
+    load_task(conn, id)
+}
+
+fn load_task(conn: &Connection, id: &str) -> rusqlite::Result<Task> {
     let mut task = conn.query_row(
         "SELECT id, title, notes, due_date, remind_at, status, priority,
                 created_at, completed_at, order_index, pinned, repeat,
                 (SELECT COALESCE(SUM(seconds), 0) FROM time_sessions
-                 WHERE task_id = tasks.id AND end_at IS NOT NULL),
+                 WHERE task_id = tasks.id AND end_at IS NOT NULL
+                   AND deleted_at IS NULL),
                 subtasks
          FROM tasks WHERE id = ?1",
         [id],
@@ -56,12 +69,23 @@ fn load_task(conn: &Connection, id: i64) -> rusqlite::Result<Task> {
     Ok(task)
 }
 
-fn set_labels(conn: &Connection, task_id: i64, label_ids: &[i64]) -> rusqlite::Result<()> {
-    conn.execute("DELETE FROM task_labels WHERE task_id = ?1", [task_id])?;
+fn set_labels(conn: &Connection, task_id: &str, label_ids: &[String]) -> rusqlite::Result<()> {
+    let now = now_iso();
+    // Tombstone every current association, then re-assert the desired ones. The
+    // removed ones stay tombstoned (so the removal syncs); the kept ones are
+    // revived in the same pass with a fresh timestamp.
+    conn.execute(
+        "UPDATE task_labels SET deleted_at = ?1, updated_at = ?1
+         WHERE task_id = ?2 AND deleted_at IS NULL",
+        params![now, task_id],
+    )?;
     for lid in label_ids {
         conn.execute(
-            "INSERT OR IGNORE INTO task_labels (task_id, label_id) VALUES (?1, ?2)",
-            params![task_id, lid],
+            "INSERT INTO task_labels (task_id, label_id, updated_at, deleted_at)
+             VALUES (?1, ?2, ?3, NULL)
+             ON CONFLICT(task_id, label_id)
+             DO UPDATE SET deleted_at = NULL, updated_at = ?3",
+            params![task_id, lid, now],
         )?;
     }
     Ok(())
@@ -75,16 +99,17 @@ pub fn list_tasks(db: State<Db>) -> CmdResult<Vec<Task>> {
     let mut stmt = conn
         .prepare(
             "SELECT id FROM tasks
+             WHERE deleted_at IS NULL
              ORDER BY (status = 'done'), order_index ASC, created_at ASC",
         )
         .map_err(|e| e.to_string())?;
-    let ids: Vec<i64> = stmt
+    let ids: Vec<String> = stmt
         .query_map([], |r| r.get(0))
         .map_err(|e| e.to_string())?
         .collect::<rusqlite::Result<_>>()
         .map_err(|e| e.to_string())?;
     ids.into_iter()
-        .map(|id| load_task(&conn, id).map_err(|e| e.to_string()))
+        .map(|id| load_task(&conn, &id).map_err(|e| e.to_string()))
         .collect()
 }
 
@@ -92,10 +117,12 @@ pub fn list_tasks(db: State<Db>) -> CmdResult<Vec<Task>> {
 pub fn create_task(db: State<Db>, task: NewTask) -> CmdResult<Task> {
     let conn = db.conn();
     let created = now_iso();
+    let id = new_uuid();
     conn.execute(
-        "INSERT INTO tasks (title, notes, due_date, remind_at, priority, created_at, order_index, repeat)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT INTO tasks (id, title, notes, due_date, remind_at, priority, created_at, order_index, repeat, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
+            id,
             task.title.trim(),
             task.notes,
             task.due_date,
@@ -104,14 +131,14 @@ pub fn create_task(db: State<Db>, task: NewTask) -> CmdResult<Task> {
             created,
             Local::now().timestamp_millis() as f64,
             task.repeat,
+            created,
         ],
     )
     .map_err(|e| e.to_string())?;
-    let id = conn.last_insert_rowid();
     if let Some(ids) = &task.label_ids {
-        set_labels(&conn, id, ids).map_err(|e| e.to_string())?;
+        set_labels(&conn, &id, ids).map_err(|e| e.to_string())?;
     }
-    load_task(&conn, id).map_err(|e| e.to_string())
+    load_task(&conn, &id).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -154,7 +181,7 @@ pub fn update_task(db: State<Db>, patch: TaskPatch) -> CmdResult<Task> {
         .map_err(|e| e.to_string())?;
     }
     if let Some(ids) = &patch.label_ids {
-        set_labels(&conn, patch.id, ids).map_err(|e| e.to_string())?;
+        set_labels(&conn, &patch.id, ids).map_err(|e| e.to_string())?;
     }
     if let Some(pinned) = patch.pinned {
         conn.execute(
@@ -180,25 +207,25 @@ pub fn update_task(db: State<Db>, patch: TaskPatch) -> CmdResult<Task> {
         )
         .map_err(|e| e.to_string())?;
     }
-    load_task(&conn, patch.id).map_err(|e| e.to_string())
+    touch_and_load(&conn, &patch.id).map_err(|e| e.to_string())
 }
 
 /// Set a task's manual order position. The frontend computes `order_index`
 /// as the midpoint between the drop target's neighbors (a fractional index),
 /// so reordering never has to renumber the whole list.
 #[tauri::command]
-pub fn reorder_task(db: State<Db>, id: i64, order_index: f64) -> CmdResult<Task> {
+pub fn reorder_task(db: State<Db>, id: String, order_index: f64) -> CmdResult<Task> {
     let conn = db.conn();
     conn.execute(
         "UPDATE tasks SET order_index = ?1 WHERE id = ?2",
         params![order_index, id],
     )
     .map_err(|e| e.to_string())?;
-    load_task(&conn, id).map_err(|e| e.to_string())
+    touch_and_load(&conn, &id).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
+pub fn toggle_task(db: State<Db>, id: String, done: bool) -> CmdResult<Task> {
     let conn = db.conn();
     // Completing a repeating task rolls it forward to the next occurrence and
     // keeps it active, instead of marking it done.
@@ -206,7 +233,7 @@ pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
         let (repeat, due, remind) = conn
             .query_row(
                 "SELECT repeat, due_date, remind_at FROM tasks WHERE id = ?1",
-                [id],
+                [&id],
                 |r| {
                     Ok((
                         r.get::<_, Option<String>>(0)?,
@@ -227,7 +254,7 @@ pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
                     params![next_due, next_remind, id],
                 )
                 .map_err(|e| e.to_string())?;
-                return load_task(&conn, id).map_err(|e| e.to_string());
+                return touch_and_load(&conn, &id).map_err(|e| e.to_string());
             }
         }
     }
@@ -239,18 +266,22 @@ pub fn toggle_task(db: State<Db>, id: i64, done: bool) -> CmdResult<Task> {
     } else {
         conn.execute(
             "UPDATE tasks SET status = 'active', completed_at = NULL WHERE id = ?1",
-            [id],
+            [&id],
         )
     }
     .map_err(|e| e.to_string())?;
-    load_task(&conn, id).map_err(|e| e.to_string())
+    touch_and_load(&conn, &id).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub fn delete_task(db: State<Db>, id: i64) -> CmdResult<()> {
+pub fn delete_task(db: State<Db>, id: String) -> CmdResult<()> {
     let conn = db.conn();
-    conn.execute("DELETE FROM tasks WHERE id = ?1", [id])
-        .map_err(|e| e.to_string())?;
+    let now = now_iso();
+    conn.execute(
+        "UPDATE tasks SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
+        params![now, id],
+    )
+    .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -258,7 +289,11 @@ pub fn delete_task(db: State<Db>, id: i64) -> CmdResult<()> {
 pub fn list_labels(db: State<Db>) -> CmdResult<Vec<Label>> {
     let conn = db.conn();
     let mut stmt = conn
-        .prepare("SELECT id, name, color FROM labels ORDER BY name COLLATE NOCASE")
+        .prepare(
+            "SELECT id, name, color FROM labels
+             WHERE deleted_at IS NULL
+             ORDER BY name COLLATE NOCASE",
+        )
         .map_err(|e| e.to_string())?;
     let labels = stmt
         .query_map([], |r| {
@@ -277,25 +312,10 @@ pub fn list_labels(db: State<Db>) -> CmdResult<Vec<Label>> {
 #[tauri::command]
 pub fn create_label(db: State<Db>, name: String, color: String) -> CmdResult<Label> {
     let conn = db.conn();
+    let id = new_uuid();
     conn.execute(
-        "INSERT INTO labels (name, color) VALUES (?1, ?2)",
-        params![name.trim(), color],
-    )
-    .map_err(|e| e.to_string())?;
-    let id = conn.last_insert_rowid();
-    Ok(Label {
-        id,
-        name: name.trim().to_string(),
-        color,
-    })
-}
-
-#[tauri::command]
-pub fn update_label(db: State<Db>, id: i64, name: String, color: String) -> CmdResult<Label> {
-    let conn = db.conn();
-    conn.execute(
-        "UPDATE labels SET name = ?1, color = ?2 WHERE id = ?3",
-        params![name.trim(), color, id],
+        "INSERT INTO labels (id, name, color, updated_at) VALUES (?1, ?2, ?3, ?4)",
+        params![id, name.trim(), color, now_iso()],
     )
     .map_err(|e| e.to_string())?;
     Ok(Label {
@@ -306,9 +326,28 @@ pub fn update_label(db: State<Db>, id: i64, name: String, color: String) -> CmdR
 }
 
 #[tauri::command]
-pub fn delete_label(db: State<Db>, id: i64) -> CmdResult<()> {
+pub fn update_label(db: State<Db>, id: String, name: String, color: String) -> CmdResult<Label> {
     let conn = db.conn();
-    conn.execute("DELETE FROM labels WHERE id = ?1", [id])
-        .map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE labels SET name = ?1, color = ?2, updated_at = ?3 WHERE id = ?4",
+        params![name.trim(), color, now_iso(), id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(Label {
+        id,
+        name: name.trim().to_string(),
+        color,
+    })
+}
+
+#[tauri::command]
+pub fn delete_label(db: State<Db>, id: String) -> CmdResult<()> {
+    let conn = db.conn();
+    let now = now_iso();
+    conn.execute(
+        "UPDATE labels SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
+        params![now, id],
+    )
+    .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,5 +1,13 @@
 use rusqlite::{params, Connection};
+use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard};
+
+/// A fresh v4 UUID as a lowercase hyphenated string — the on-device id for a
+/// syncable row (task, label, focus session). Matches Postgres `uuid` text
+/// form so the same value round-trips to the cloud database unchanged.
+pub fn new_uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
 
 /// Managed Tauri state: a single SQLite connection behind a mutex.
 /// The notification scheduler and the command handlers share this.
@@ -27,13 +35,15 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
         PRAGMA foreign_keys = ON;
 
         CREATE TABLE IF NOT EXISTS labels (
-            id    INTEGER PRIMARY KEY AUTOINCREMENT,
-            name  TEXT NOT NULL,
-            color TEXT NOT NULL DEFAULT '#6c7cff'
+            id         TEXT PRIMARY KEY,   -- UUID, generated on-device
+            name       TEXT NOT NULL,
+            color      TEXT NOT NULL DEFAULT '#6c7cff',
+            updated_at TEXT NOT NULL,      -- RFC3339, bumped on every write
+            deleted_at TEXT                -- soft-delete tombstone; NULL while live
         );
 
         CREATE TABLE IF NOT EXISTS tasks (
-            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            id           TEXT PRIMARY KEY,   -- UUID, generated on-device
             title        TEXT NOT NULL,
             notes        TEXT,
             due_date     TEXT,               -- ISO date  (YYYY-MM-DD)
@@ -46,12 +56,16 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
             notified     INTEGER NOT NULL DEFAULT 0,
             pinned       INTEGER NOT NULL DEFAULT 0,
             repeat       TEXT,               -- daily|weekdays|weekly|monthly|yearly
-            subtasks     TEXT                -- JSON array of {id,text,done}
+            subtasks     TEXT,               -- JSON array of {id,text,done}
+            updated_at   TEXT NOT NULL,      -- RFC3339, bumped on every write
+            deleted_at   TEXT                -- soft-delete tombstone; NULL while live
         );
 
         CREATE TABLE IF NOT EXISTS task_labels (
-            task_id  INTEGER NOT NULL REFERENCES tasks(id)  ON DELETE CASCADE,
-            label_id INTEGER NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+            task_id    TEXT NOT NULL REFERENCES tasks(id)  ON DELETE CASCADE,
+            label_id   TEXT NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+            updated_at TEXT NOT NULL,   -- RFC3339, bumped on every write
+            deleted_at TEXT,            -- soft-delete tombstone; NULL while live
             PRIMARY KEY (task_id, label_id)
         );
 
@@ -66,12 +80,14 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
         -- one currently running (at most one at a time). `seconds` is filled in
         -- on stop; `notified` counts the 'still tracking' nudges already sent.
         CREATE TABLE IF NOT EXISTS time_sessions (
-            id       INTEGER PRIMARY KEY AUTOINCREMENT,
-            task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-            start_at TEXT NOT NULL,   -- RFC3339
-            end_at   TEXT,            -- NULL while running
-            seconds  INTEGER,         -- duration, set on stop
-            notified INTEGER NOT NULL DEFAULT 0
+            id         TEXT PRIMARY KEY,   -- UUID, generated on-device
+            task_id    TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+            start_at   TEXT NOT NULL,   -- RFC3339
+            end_at     TEXT,            -- NULL while running
+            seconds    INTEGER,         -- duration, set on stop
+            notified   INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL,   -- RFC3339, bumped on every write
+            deleted_at TEXT             -- soft-delete tombstone; NULL while live
         );
         CREATE INDEX IF NOT EXISTS idx_sessions_task ON time_sessions(task_id);
 
@@ -143,5 +159,504 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         conn.execute("ALTER TABLE tasks ADD COLUMN subtasks TEXT", [])?;
     }
 
+    // Integer -> UUID primary keys, so records created offline on separate
+    // devices merge into a shared cloud database without id collisions. Runs
+    // once on databases still using the old AUTOINCREMENT integer ids; a no-op
+    // afterwards and on fresh installs (which are created with TEXT ids above).
+    // Must come after the column-adding blocks so it can carry every column.
+    migrate_ids_to_uuid(conn)?;
+
+    // Sync bookkeeping: `updated_at` for last-write-wins ordering and
+    // `deleted_at` tombstones so deletions propagate instead of vanishing.
+    // Runs after the UUID conversion so it only ever touches TEXT-keyed tables.
+    add_sync_columns(conn)?;
+
     Ok(())
+}
+
+/// Add `updated_at` / `deleted_at` to a syncable table, backfilling
+/// `updated_at` from an existing timestamp column so pre-sync rows get a sane
+/// baseline. Idempotent via the column guards.
+fn add_sync_columns(conn: &Connection) -> rusqlite::Result<()> {
+    for (table, backfill) in [
+        ("tasks", "created_at"),
+        ("labels", "'1970-01-01T00:00:00+00:00'"),
+        ("time_sessions", "start_at"),
+        ("task_labels", "'1970-01-01T00:00:00+00:00'"),
+    ] {
+        if !column_exists(conn, table, "updated_at") {
+            conn.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''"),
+                [],
+            )?;
+            conn.execute(
+                &format!("UPDATE {table} SET updated_at = {backfill} WHERE updated_at = ''"),
+                [],
+            )?;
+        }
+        if !column_exists(conn, table, "deleted_at") {
+            conn.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN deleted_at TEXT"),
+                [],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// True while `tasks.id` is still declared `INTEGER` — i.e. this database was
+/// created before the UUID switch and still needs converting.
+fn ids_are_integer(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT type FROM pragma_table_info('tasks') WHERE name = 'id'",
+        [],
+        |r| r.get::<_, String>(0),
+    )
+    .map(|t| t.eq_ignore_ascii_case("integer"))
+    .unwrap_or(false)
+}
+
+/// One integer-keyed task row, read into memory before the tables are rewritten.
+struct TaskRow {
+    id: String, // freshly assigned UUID
+    title: String,
+    notes: Option<String>,
+    due_date: Option<String>,
+    remind_at: Option<String>,
+    status: String,
+    priority: i64,
+    created_at: String,
+    completed_at: Option<String>,
+    order_index: f64,
+    notified: i64,
+    pinned: i64,
+    repeat: Option<String>,
+    subtasks: Option<String>,
+}
+
+/// One integer-keyed focus session, read into memory before the rewrite.
+struct SessionRow {
+    id: String, // freshly assigned UUID
+    task_id: String,
+    start_at: String,
+    end_at: Option<String>,
+    seconds: Option<i64>,
+    notified: i64,
+}
+
+/// Convert the syncable tables (`labels`, `tasks`, `task_labels`,
+/// `time_sessions`) from integer AUTOINCREMENT ids to on-device UUIDs.
+///
+/// Everything is read into memory first so old integer ids can be remapped to
+/// their new UUIDs consistently across foreign keys, then the tables are
+/// dropped and recreated with TEXT keys and the remapped rows re-inserted. The
+/// recreate DDL mirrors the `CREATE TABLE` statements in [`init`] — keep the
+/// two in sync if the schema changes. `pomodoro` and `settings` are untouched
+/// (singleton / device-local, never synced).
+fn migrate_ids_to_uuid(conn: &Connection) -> rusqlite::Result<()> {
+    if !ids_are_integer(conn) {
+        return Ok(());
+    }
+
+    // 1. Read labels, assigning a UUID to each old id.
+    let mut label_map: HashMap<i64, String> = HashMap::new();
+    let labels: Vec<(String, String, String)> = {
+        let mut stmt = conn.prepare("SELECT id, name, color FROM labels")?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?, r.get::<_, String>(2)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .map(|(old, name, color)| {
+                let nid = new_uuid();
+                label_map.insert(old, nid.clone());
+                (nid, name, color)
+            })
+            .collect()
+    };
+
+    // 2. Read tasks, assigning a UUID to each old id.
+    let mut task_map: HashMap<i64, String> = HashMap::new();
+    let tasks: Vec<TaskRow> = {
+        let mut stmt = conn.prepare(
+            "SELECT id, title, notes, due_date, remind_at, status, priority,
+                    created_at, completed_at, order_index, notified, pinned,
+                    repeat, subtasks
+             FROM tasks",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                let old: i64 = r.get(0)?;
+                Ok((
+                    old,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, String>(5)?,
+                    r.get::<_, i64>(6)?,
+                    r.get::<_, String>(7)?,
+                    r.get::<_, Option<String>>(8)?,
+                    r.get::<_, f64>(9)?,
+                    r.get::<_, i64>(10)?,
+                    r.get::<_, i64>(11)?,
+                    r.get::<_, Option<String>>(12)?,
+                    r.get::<_, Option<String>>(13)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .map(|t| {
+                let nid = new_uuid();
+                task_map.insert(t.0, nid.clone());
+                TaskRow {
+                    id: nid,
+                    title: t.1,
+                    notes: t.2,
+                    due_date: t.3,
+                    remind_at: t.4,
+                    status: t.5,
+                    priority: t.6,
+                    created_at: t.7,
+                    completed_at: t.8,
+                    order_index: t.9,
+                    notified: t.10,
+                    pinned: t.11,
+                    repeat: t.12,
+                    subtasks: t.13,
+                }
+            })
+            .collect()
+    };
+
+    // 3. Read the join rows and sessions, remapping their foreign keys. Rows
+    //    whose parent is missing (shouldn't happen with FKs on) are dropped.
+    let task_labels: Vec<(String, String)> = {
+        let mut stmt = conn.prepare("SELECT task_id, label_id FROM task_labels")?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .filter_map(|(t, l)| Some((task_map.get(&t)?.clone(), label_map.get(&l)?.clone())))
+            .collect()
+    };
+    let sessions: Vec<SessionRow> = {
+        let mut stmt = conn
+            .prepare("SELECT id, task_id, start_at, end_at, seconds, notified FROM time_sessions")?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<i64>>(4)?,
+                    r.get::<_, i64>(5)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows.into_iter()
+            .filter_map(|(task, start_at, end_at, seconds, notified)| {
+                Some(SessionRow {
+                    id: new_uuid(),
+                    task_id: task_map.get(&task)?.clone(),
+                    start_at,
+                    end_at,
+                    seconds,
+                    notified,
+                })
+            })
+            .collect()
+    };
+
+    // 4. Rewrite. Disable FK enforcement so dropping/recreating the tables in
+    //    dependency order doesn't cascade-delete children mid-swap.
+    conn.execute_batch(
+        "
+        PRAGMA foreign_keys = OFF;
+        DROP TABLE task_labels;
+        DROP TABLE time_sessions;
+        DROP TABLE tasks;
+        DROP TABLE labels;
+
+        CREATE TABLE labels (
+            id    TEXT PRIMARY KEY,
+            name  TEXT NOT NULL,
+            color TEXT NOT NULL DEFAULT '#6c7cff'
+        );
+        CREATE TABLE tasks (
+            id           TEXT PRIMARY KEY,
+            title        TEXT NOT NULL,
+            notes        TEXT,
+            due_date     TEXT,
+            remind_at    TEXT,
+            status       TEXT NOT NULL DEFAULT 'active',
+            priority     INTEGER NOT NULL DEFAULT 4,
+            created_at   TEXT NOT NULL,
+            completed_at TEXT,
+            order_index  REAL NOT NULL DEFAULT 0,
+            notified     INTEGER NOT NULL DEFAULT 0,
+            pinned       INTEGER NOT NULL DEFAULT 0,
+            repeat       TEXT,
+            subtasks     TEXT
+        );
+        CREATE TABLE task_labels (
+            task_id  TEXT NOT NULL REFERENCES tasks(id)  ON DELETE CASCADE,
+            label_id TEXT NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+            PRIMARY KEY (task_id, label_id)
+        );
+        CREATE TABLE time_sessions (
+            id       TEXT PRIMARY KEY,
+            task_id  TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+            start_at TEXT NOT NULL,
+            end_at   TEXT,
+            seconds  INTEGER,
+            notified INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX idx_sessions_task ON time_sessions(task_id);
+        CREATE INDEX idx_tasks_status  ON tasks(status);
+        CREATE INDEX idx_tasks_due     ON tasks(due_date);
+        CREATE INDEX idx_tasks_remind  ON tasks(remind_at);
+        CREATE INDEX idx_tasks_pinned  ON tasks(pinned);
+        ",
+    )?;
+
+    for (id, name, color) in &labels {
+        conn.execute(
+            "INSERT INTO labels (id, name, color) VALUES (?1, ?2, ?3)",
+            params![id, name, color],
+        )?;
+    }
+    for t in &tasks {
+        conn.execute(
+            "INSERT INTO tasks (id, title, notes, due_date, remind_at, status,
+                                priority, created_at, completed_at, order_index,
+                                notified, pinned, repeat, subtasks)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                t.id,
+                t.title,
+                t.notes,
+                t.due_date,
+                t.remind_at,
+                t.status,
+                t.priority,
+                t.created_at,
+                t.completed_at,
+                t.order_index,
+                t.notified,
+                t.pinned,
+                t.repeat,
+                t.subtasks,
+            ],
+        )?;
+    }
+    for (task_id, label_id) in &task_labels {
+        conn.execute(
+            "INSERT INTO task_labels (task_id, label_id) VALUES (?1, ?2)",
+            params![task_id, label_id],
+        )?;
+    }
+    for s in &sessions {
+        conn.execute(
+            "INSERT INTO time_sessions (id, task_id, start_at, end_at, seconds, notified)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![s.id, s.task_id, s.start_at, s.end_at, s.seconds, s.notified],
+        )?;
+    }
+
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a database on the pre-UUID schema (integer AUTOINCREMENT ids) with
+    /// a few interlinked rows, exactly as an older install would have on disk.
+    fn seed_legacy(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE labels (
+                id    INTEGER PRIMARY KEY AUTOINCREMENT,
+                name  TEXT NOT NULL,
+                color TEXT NOT NULL DEFAULT '#6c7cff'
+            );
+            CREATE TABLE tasks (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                title        TEXT NOT NULL,
+                notes        TEXT,
+                due_date     TEXT,
+                remind_at    TEXT,
+                status       TEXT NOT NULL DEFAULT 'active',
+                priority     INTEGER NOT NULL DEFAULT 4,
+                created_at   TEXT NOT NULL,
+                completed_at TEXT,
+                order_index  REAL NOT NULL DEFAULT 0,
+                notified     INTEGER NOT NULL DEFAULT 0,
+                pinned       INTEGER NOT NULL DEFAULT 0,
+                repeat       TEXT,
+                subtasks     TEXT
+            );
+            CREATE TABLE task_labels (
+                task_id  INTEGER NOT NULL REFERENCES tasks(id)  ON DELETE CASCADE,
+                label_id INTEGER NOT NULL REFERENCES labels(id) ON DELETE CASCADE,
+                PRIMARY KEY (task_id, label_id)
+            );
+            CREATE TABLE time_sessions (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+                start_at TEXT NOT NULL,
+                end_at   TEXT,
+                seconds  INTEGER,
+                notified INTEGER NOT NULL DEFAULT 0
+            );
+
+            INSERT INTO labels (id, name, color) VALUES
+                (1, 'home', '#111111'), (2, 'work', '#222222');
+            INSERT INTO tasks (id, title, created_at, order_index) VALUES
+                (10, 'buy milk', '2026-01-01T00:00:00+00:00', 1.0),
+                (11, 'ship it',  '2026-01-02T00:00:00+00:00', 2.0);
+            INSERT INTO task_labels (task_id, label_id) VALUES
+                (10, 1), (11, 1), (11, 2);
+            INSERT INTO time_sessions (id, task_id, start_at, end_at, seconds) VALUES
+                (100, 11, '2026-01-02T09:00:00+00:00', '2026-01-02T09:30:00+00:00', 1800);
+            ",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn migrates_integer_ids_to_uuids() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_legacy(&conn);
+
+        // init() runs the CREATE TABLE IF NOT EXISTS (no-ops on the existing
+        // tables) then migrate(), which performs the UUID conversion.
+        init(&conn).unwrap();
+
+        // tasks.id is now TEXT.
+        let id_type: String = conn
+            .query_row(
+                "SELECT type FROM pragma_table_info('tasks') WHERE name = 'id'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(id_type, "TEXT");
+
+        // Row counts preserved.
+        let tasks: i64 = conn
+            .query_row("SELECT COUNT(*) FROM tasks", [], |r| r.get(0))
+            .unwrap();
+        let labels: i64 = conn
+            .query_row("SELECT COUNT(*) FROM labels", [], |r| r.get(0))
+            .unwrap();
+        let links: i64 = conn
+            .query_row("SELECT COUNT(*) FROM task_labels", [], |r| r.get(0))
+            .unwrap();
+        let sessions: i64 = conn
+            .query_row("SELECT COUNT(*) FROM time_sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!((tasks, labels, links, sessions), (2, 2, 3, 1));
+
+        // Every id is now a 36-char UUID string, not a small integer.
+        let task_id: String = conn
+            .query_row("SELECT id FROM tasks WHERE title = 'ship it'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(task_id.len(), 36);
+
+        // Foreign keys were remapped consistently: 'ship it' still has exactly
+        // its two labels, joined by the new UUIDs.
+        let ship_labels: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_labels tl
+                 JOIN tasks t ON t.id = tl.task_id
+                 WHERE t.title = 'ship it'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ship_labels, 2);
+
+        // The focus session still points at 'ship it' via the remapped key.
+        let session_task: String = conn
+            .query_row(
+                "SELECT t.title FROM time_sessions s JOIN tasks t ON t.id = s.task_id",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_task, "ship it");
+
+        // Running init() again is a no-op (ids already TEXT) and preserves ids.
+        init(&conn).unwrap();
+        let same: String = conn
+            .query_row("SELECT id FROM tasks WHERE title = 'ship it'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(same, task_id);
+    }
+
+    #[test]
+    fn adds_sync_columns_and_backfills() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_legacy(&conn);
+        init(&conn).unwrap();
+
+        // updated_at is backfilled from created_at, deleted_at starts NULL.
+        let (updated, deleted): (String, Option<String>) = conn
+            .query_row(
+                "SELECT updated_at, deleted_at FROM tasks WHERE title = 'buy milk'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(updated, "2026-01-01T00:00:00+00:00");
+        assert_eq!(deleted, None);
+
+        for table in ["labels", "time_sessions"] {
+            let n: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE updated_at = ''"),
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, 0, "{table} has un-backfilled updated_at");
+        }
+    }
+
+    #[test]
+    fn delete_is_a_tombstone() {
+        let conn = Connection::open_in_memory().unwrap();
+        init(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO tasks (id, title, created_at, updated_at) VALUES ('t1', 'x', 'c', 'c')",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "UPDATE tasks SET deleted_at = 'now', updated_at = 'now' WHERE id = 't1'",
+            [],
+        )
+        .unwrap();
+
+        let live: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tasks WHERE deleted_at IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM tasks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!((live, total), (0, 1));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,9 +4,11 @@ mod models;
 mod notify;
 mod popup;
 mod quickwin;
+mod secret;
 mod recur;
 mod scheduler;
 mod settings;
+mod sync;
 mod timer;
 mod tray;
 
@@ -120,6 +122,7 @@ pub fn run() {
             notify::send_test_notification,
             popup::notify_popup_dismiss,
             popup::notify_popup_open,
+            popup::notify_popup_pending,
             settings::get_setting,
             settings::set_setting,
             settings::get_autostart,
@@ -134,6 +137,15 @@ pub fn run() {
             timer::pomodoro_reset,
             timer::pomodoro_next,
             timer::set_pomodoro_config,
+            sync::sync_changes_since,
+            sync::sync_apply,
+            sync::sync_get_watermark,
+            sync::sync_set_watermark,
+            sync::sync_reset,
+            sync::sync_purge_tombstones,
+            secret::secret_get,
+            secret::secret_set,
+            secret::secret_delete,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -15,7 +15,7 @@ where
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Label {
-    pub id: i64,
+    pub id: String,
     pub name: String,
     pub color: String,
 }
@@ -33,7 +33,7 @@ pub struct Subtask {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Task {
-    pub id: i64,
+    pub id: String,
     pub title: String,
     pub notes: Option<String>,
     pub due_date: Option<String>,
@@ -49,7 +49,7 @@ pub struct Task {
     /// Total focused seconds from completed stopwatch sessions.
     pub tracked_seconds: i64,
     /// Label ids attached to this task.
-    pub label_ids: Vec<i64>,
+    pub label_ids: Vec<String>,
     /// Checklist steps for breaking the task into smaller chunks.
     pub subtasks: Vec<Subtask>,
 }
@@ -63,7 +63,7 @@ pub struct NewTask {
     pub due_date: Option<String>,
     pub remind_at: Option<String>,
     pub priority: Option<i64>,
-    pub label_ids: Option<Vec<i64>>,
+    pub label_ids: Option<Vec<String>>,
     pub repeat: Option<String>,
 }
 
@@ -71,7 +71,7 @@ pub struct NewTask {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskPatch {
-    pub id: i64,
+    pub id: String,
     pub title: Option<String>,
     #[serde(default, deserialize_with = "double_option")]
     pub notes: Option<Option<String>>,
@@ -80,7 +80,7 @@ pub struct TaskPatch {
     #[serde(default, deserialize_with = "double_option")]
     pub remind_at: Option<Option<String>>,
     pub priority: Option<i64>,
-    pub label_ids: Option<Vec<i64>>,
+    pub label_ids: Option<Vec<String>>,
     pub pinned: Option<bool>,
     /// `Some(None)` clears the recurrence; `Some(Some(rule))` sets it.
     #[serde(default, deserialize_with = "double_option")]
@@ -93,7 +93,7 @@ pub struct TaskPatch {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveTimer {
-    pub task_id: i64,
+    pub task_id: String,
     pub title: String,
     pub start_at: String,
 }
@@ -102,8 +102,8 @@ pub struct ActiveTimer {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionLog {
-    pub id: i64,
-    pub task_id: i64,
+    pub id: String,
+    pub task_id: String,
     pub title: String,
     pub start_at: String,
     pub end_at: String,

--- a/src-tauri/src/notify.rs
+++ b/src-tauri/src/notify.rs
@@ -16,7 +16,7 @@ use tauri_plugin_notification::NotificationExt;
 /// Show a desktop notification with `title` and `body`, routed per the user's
 /// chosen style. `task_id` lets the custom popup open the right task on click.
 /// Best-effort.
-pub fn send(app: &AppHandle, title: &str, body: &str, task_id: Option<i64>) {
+pub fn send(app: &AppHandle, title: &str, body: &str, task_id: Option<String>) {
     let _ = deliver(app, title, body, task_id);
 }
 
@@ -27,7 +27,7 @@ pub fn deliver(
     app: &AppHandle,
     title: &str,
     body: &str,
-    task_id: Option<i64>,
+    task_id: Option<String>,
 ) -> Result<&'static str, String> {
     let style = {
         let db = app.state::<Db>();

--- a/src-tauri/src/popup.rs
+++ b/src-tauri/src/popup.rs
@@ -7,6 +7,9 @@
 
 use crate::db::Db;
 use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, PhysicalPosition};
 
 /// Label of the popup window, defined in tauri.conf.json.
@@ -15,20 +18,38 @@ pub const POPUP_LABEL: &str = "notification";
 /// Gap (logical px) between the popup and the screen edges.
 const MARGIN: i32 = 16;
 
+/// The popup hides itself this long after showing even if the webview never
+/// acknowledges it. A backstop: the window is transparent and always-on-top,
+/// so a dropped `notify-show` event (e.g. the webview wasn't ready yet) would
+/// otherwise leave an invisible frame swallowing clicks in the screen corner.
+const SAFETY_HIDE_MS: u64 = 7000;
+
+/// Monotonic id of the most recently shown popup. The safety-hide task only
+/// hides if it still matches, so it never closes a newer popup.
+static LATEST_NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// The notification currently on screen, so a webview that mounts after the
+/// event was emitted can still fetch and render it (see [`notify_popup_pending`]).
+static LAST_PAYLOAD: Mutex<Option<PopupPayload>> = Mutex::new(None);
+
+fn set_last(payload: Option<PopupPayload>) {
+    *LAST_PAYLOAD.lock().unwrap_or_else(|e| e.into_inner()) = payload;
+}
+
 /// Payload sent to the popup webview so it can render the card.
 #[derive(Serialize, Clone)]
-struct PopupPayload {
+pub struct PopupPayload {
     /// Unique per show, so the webview resets its auto-dismiss timer.
     nonce: u64,
     title: String,
     body: String,
     /// Task to open when the user clicks the card, if any.
-    task_id: Option<i64>,
+    task_id: Option<String>,
 }
 
 /// Position the popup in the configured corner, push the content to its webview,
 /// and show it without stealing focus.
-pub fn show(app: &AppHandle, title: &str, body: &str, task_id: Option<i64>) {
+pub fn show(app: &AppHandle, title: &str, body: &str, task_id: Option<String>) {
     let Some(win) = app.get_webview_window(POPUP_LABEL) else {
         return;
     };
@@ -43,17 +64,47 @@ pub fn show(app: &AppHandle, title: &str, body: &str, task_id: Option<i64>) {
         let _ = win.set_position(pos);
     }
 
-    use std::sync::atomic::{AtomicU64, Ordering};
     static NONCE: AtomicU64 = AtomicU64::new(1);
+    let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
     let payload = PopupPayload {
-        nonce: NONCE.fetch_add(1, Ordering::Relaxed),
+        nonce,
         title: title.to_owned(),
         body: body.to_owned(),
         task_id,
     };
-    let _ = win.emit_to(POPUP_LABEL, "notify-show", payload);
+
+    // Record it before showing so a late-mounting webview can pull it, then
+    // show and emit. Emitting after `show()` gives the webview a beat to be
+    // listening; the pending-fetch and safety-hide cover it if it still isn't.
+    set_last(Some(payload.clone()));
+    LATEST_NONCE.store(nonce, Ordering::Relaxed);
     let _ = win.show();
     let _ = win.set_always_on_top(true);
+    let _ = win.emit_to(POPUP_LABEL, "notify-show", payload);
+
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(SAFETY_HIDE_MS));
+        if LATEST_NONCE.load(Ordering::Relaxed) == nonce {
+            hide(&app);
+        }
+    });
+}
+
+/// Hide the popup window and forget the pending notification.
+fn hide(app: &AppHandle) {
+    if let Some(win) = app.get_webview_window(POPUP_LABEL) {
+        let _ = win.hide();
+    }
+    set_last(None);
+}
+
+/// The notification currently on screen, if any. The webview calls this on
+/// mount so it renders the active popup even when it started after the
+/// `notify-show` event was emitted.
+#[tauri::command]
+pub fn notify_popup_pending() -> Option<PopupPayload> {
+    LAST_PAYLOAD.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
 
 /// Top-left corner (physical px) for the popup on the current monitor.
@@ -92,15 +143,13 @@ fn corner_position(
 /// Hide the popup (called by the webview when it auto-dismisses or is closed).
 #[tauri::command]
 pub fn notify_popup_dismiss(app: AppHandle) {
-    if let Some(win) = app.get_webview_window(POPUP_LABEL) {
-        let _ = win.hide();
-    }
+    hide(&app);
 }
 
 /// Bring the main window forward (optionally selecting a task) and hide the
 /// popup — the action behind clicking the notification card.
 #[tauri::command]
-pub fn notify_popup_open(app: AppHandle, task_id: Option<i64>) {
+pub fn notify_popup_open(app: AppHandle, task_id: Option<String>) {
     if let Some(main) = app.get_webview_window("main") {
         let _ = main.show();
         let _ = main.unminimize();
@@ -109,7 +158,5 @@ pub fn notify_popup_open(app: AppHandle, task_id: Option<i64>) {
             let _ = main.emit("reminder-open", id);
         }
     }
-    if let Some(win) = app.get_webview_window(POPUP_LABEL) {
-        let _ = win.hide();
-    }
+    hide(&app);
 }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -13,7 +13,7 @@ const DEFAULT_REMINDER_HOUR: u32 = 9;
 /// `reminder-fired` event the frontend listens for.
 #[derive(Serialize, Clone)]
 struct DueReminder {
-    id: i64,
+    id: String,
     title: String,
 }
 
@@ -44,7 +44,7 @@ fn tick(app: &AppHandle) -> Result<(), String> {
             // Fires even when the window is hidden in the tray, since this runs
             // on a background thread. Routes to the custom popup or the OS per
             // the user's setting.
-            crate::notify::send(app, &r.title, "⏰ Reminder · todofy", Some(r.id));
+            crate::notify::send(app, &r.title, "⏰ Reminder · todofy", Some(r.id.clone()));
         }
         // The custom popup already is our in-app surface; only emit the toast
         // for the main window when we're using OS notifications, to avoid a
@@ -70,7 +70,7 @@ fn collect_due(app: &AppHandle) -> Result<Vec<DueReminder>, String> {
     let mut stmt = conn
         .prepare(
             "SELECT id, title, remind_at, due_date FROM tasks
-             WHERE status = 'active' AND notified = 0
+             WHERE status = 'active' AND notified = 0 AND deleted_at IS NULL
                AND (remind_at IS NOT NULL OR due_date IS NOT NULL)",
         )
         .map_err(|e| e.to_string())?;
@@ -78,21 +78,21 @@ fn collect_due(app: &AppHandle) -> Result<Vec<DueReminder>, String> {
     let rows = stmt
         .query_map([], |r| {
             Ok((
-                r.get::<_, i64>(0)?,
+                r.get::<_, String>(0)?,
                 r.get::<_, String>(1)?,
                 r.get::<_, Option<String>>(2)?,
                 r.get::<_, Option<String>>(3)?,
             ))
         })
         .map_err(|e| e.to_string())?
-        .collect::<rusqlite::Result<Vec<(i64, String, Option<String>, Option<String>)>>>()
+        .collect::<rusqlite::Result<Vec<(String, String, Option<String>, Option<String>)>>>()
         .map_err(|e| e.to_string())?;
 
     let mut due = Vec::new();
     for (id, title, remind_at, due_date) in rows {
         let fires_at = reminder_instant(remind_at.as_deref(), due_date.as_deref());
         if fires_at.map(|t| t <= now).unwrap_or(false) {
-            conn.execute("UPDATE tasks SET notified = 1 WHERE id = ?1", [id])
+            conn.execute("UPDATE tasks SET notified = 1 WHERE id = ?1", [&id])
                 .map_err(|e| e.to_string())?;
             due.push(DueReminder { id, title });
         }

--- a/src-tauri/src/secret.rs
+++ b/src-tauri/src/secret.rs
@@ -1,0 +1,35 @@
+//! Thin wrapper over the OS keychain for the account session. The frontend
+//! points its Supabase client's storage at these commands so access/refresh
+//! tokens live in the platform secret store instead of the webview's
+//! localStorage. If the platform has no working keychain the frontend falls
+//! back to localStorage on its own, so these never block sign-in.
+
+use keyring::Entry;
+
+const SERVICE: &str = "todofy";
+
+fn entry(key: &str) -> Result<Entry, String> {
+    Entry::new(SERVICE, key).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn secret_get(key: String) -> Result<Option<String>, String> {
+    match entry(&key)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn secret_set(key: String, value: String) -> Result<(), String> {
+    entry(&key)?.set_password(&value).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn secret_delete(key: String) -> Result<(), String> {
+    match entry(&key)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -14,7 +14,7 @@ pub fn read(conn: &Connection, key: &str) -> Option<String> {
 }
 
 /// Upsert a setting value.
-fn write(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
+pub fn write(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
     conn.execute(
         "INSERT INTO settings (key, value) VALUES (?1, ?2)
          ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -1,0 +1,488 @@
+//! Local half of account sync. The frontend owns the Supabase session and
+//! drives each round: pull remote rows into [`sync_apply`], then push the
+//! changes from [`sync_changes_since`]. Last-write-wins by `updated_at`,
+//! compared as parsed instants (offsets differ between local and cloud). Field
+//! names match the Postgres columns so rows forward to Supabase unremapped.
+
+use crate::db::Db;
+use crate::settings;
+use chrono::DateTime;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::State;
+
+const WATERMARK_KEY: &str = "sync_last_synced_at";
+const EPOCH: &str = "1970-01-01T00:00:00+00:00";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncTask {
+    pub id: String,
+    pub title: String,
+    pub notes: Option<String>,
+    pub due_date: Option<String>,
+    pub remind_at: Option<String>,
+    pub status: String,
+    pub priority: i64,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+    pub order_index: f64,
+    pub pinned: bool,
+    pub repeat: Option<String>,
+    pub subtasks: Value,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncLabel {
+    pub id: String,
+    pub name: String,
+    pub color: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncTaskLabel {
+    pub task_id: String,
+    pub label_id: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncSession {
+    pub id: String,
+    pub task_id: String,
+    pub start_at: String,
+    pub end_at: Option<String>,
+    pub seconds: Option<i64>,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct SyncBundle {
+    pub tasks: Vec<SyncTask>,
+    pub labels: Vec<SyncLabel>,
+    pub task_labels: Vec<SyncTaskLabel>,
+    pub sessions: Vec<SyncSession>,
+}
+
+/// True when `a` is strictly newer than `b`. If either fails to parse we treat
+/// `a` as newer, so a questionable row propagates rather than being dropped.
+fn newer(a: &str, b: &str) -> bool {
+    match (DateTime::parse_from_rfc3339(a), DateTime::parse_from_rfc3339(b)) {
+        (Ok(a), Ok(b)) => a > b,
+        _ => true,
+    }
+}
+
+fn subtasks_value(raw: Option<String>) -> Value {
+    raw.and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| Value::Array(vec![]))
+}
+
+// ------------------------------------------------------------------- push side
+
+/// Every local row changed since `since` (tombstones included), for the caller
+/// to upsert into Supabase.
+#[tauri::command]
+pub fn sync_changes_since(db: State<Db>, since: String) -> Result<SyncBundle, String> {
+    let conn = db.conn();
+    collect_changes(&conn, &since).map_err(|e| e.to_string())
+}
+
+fn collect_changes(conn: &Connection, since: &str) -> rusqlite::Result<SyncBundle> {
+    let mut tasks = Vec::new();
+    let mut stmt = conn.prepare(
+        "SELECT id, title, notes, due_date, remind_at, status, priority, created_at,
+                completed_at, order_index, pinned, repeat, subtasks, updated_at, deleted_at
+         FROM tasks",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(SyncTask {
+            id: r.get(0)?,
+            title: r.get(1)?,
+            notes: r.get(2)?,
+            due_date: r.get(3)?,
+            remind_at: r.get(4)?,
+            status: r.get(5)?,
+            priority: r.get(6)?,
+            created_at: r.get(7)?,
+            completed_at: r.get(8)?,
+            order_index: r.get(9)?,
+            pinned: r.get::<_, i64>(10)? != 0,
+            repeat: r.get(11)?,
+            subtasks: subtasks_value(r.get(12)?),
+            updated_at: r.get(13)?,
+            deleted_at: r.get(14)?,
+        })
+    })?;
+    for row in rows {
+        let row = row?;
+        if newer(&row.updated_at, since) {
+            tasks.push(row);
+        }
+    }
+
+    let mut labels = Vec::new();
+    let mut stmt = conn.prepare("SELECT id, name, color, updated_at, deleted_at FROM labels")?;
+    let rows = stmt.query_map([], |r| {
+        Ok(SyncLabel {
+            id: r.get(0)?,
+            name: r.get(1)?,
+            color: r.get(2)?,
+            updated_at: r.get(3)?,
+            deleted_at: r.get(4)?,
+        })
+    })?;
+    for row in rows {
+        let row = row?;
+        if newer(&row.updated_at, since) {
+            labels.push(row);
+        }
+    }
+
+    let mut task_labels = Vec::new();
+    let mut stmt =
+        conn.prepare("SELECT task_id, label_id, updated_at, deleted_at FROM task_labels")?;
+    let rows = stmt.query_map([], |r| {
+        Ok(SyncTaskLabel {
+            task_id: r.get(0)?,
+            label_id: r.get(1)?,
+            updated_at: r.get(2)?,
+            deleted_at: r.get(3)?,
+        })
+    })?;
+    for row in rows {
+        let row = row?;
+        if newer(&row.updated_at, since) {
+            task_labels.push(row);
+        }
+    }
+
+    let mut sessions = Vec::new();
+    let mut stmt = conn.prepare(
+        "SELECT id, task_id, start_at, end_at, seconds, updated_at, deleted_at FROM time_sessions",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(SyncSession {
+            id: r.get(0)?,
+            task_id: r.get(1)?,
+            start_at: r.get(2)?,
+            end_at: r.get(3)?,
+            seconds: r.get(4)?,
+            updated_at: r.get(5)?,
+            deleted_at: r.get(6)?,
+        })
+    })?;
+    for row in rows {
+        let row = row?;
+        if newer(&row.updated_at, since) {
+            sessions.push(row);
+        }
+    }
+
+    Ok(SyncBundle {
+        tasks,
+        labels,
+        task_labels,
+        sessions,
+    })
+}
+
+// ------------------------------------------------------------------- pull side
+
+/// Merge a bundle of remote rows into the local database, last-write-wins by
+/// `updated_at`. Applied in FK-safe order so a freshly-pulled association never
+/// references a parent that hasn't landed yet.
+#[tauri::command]
+pub fn sync_apply(db: State<Db>, remote: SyncBundle) -> Result<(), String> {
+    let conn = db.conn();
+    apply_bundle(&conn, &remote).map_err(|e| e.to_string())
+}
+
+fn local_updated_at(conn: &Connection, sql: &str, key: &[&dyn rusqlite::ToSql]) -> Option<String> {
+    conn.query_row(sql, key, |r| r.get::<_, String>(0)).ok()
+}
+
+fn apply_bundle(conn: &Connection, remote: &SyncBundle) -> rusqlite::Result<()> {
+    for l in &remote.labels {
+        let local = local_updated_at(conn, "SELECT updated_at FROM labels WHERE id = ?1", &[&l.id]);
+        if local.as_deref().map(|cur| newer(&l.updated_at, cur)).unwrap_or(true) {
+            conn.execute(
+                "INSERT INTO labels (id, name, color, updated_at, deleted_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name, color = excluded.color,
+                    updated_at = excluded.updated_at, deleted_at = excluded.deleted_at",
+                params![l.id, l.name, l.color, l.updated_at, l.deleted_at],
+            )?;
+        }
+    }
+
+    for t in &remote.tasks {
+        let local = local_updated_at(conn, "SELECT updated_at FROM tasks WHERE id = ?1", &[&t.id]);
+        if local.as_deref().map(|cur| newer(&t.updated_at, cur)).unwrap_or(true) {
+            conn.execute(
+                "INSERT INTO tasks (id, title, notes, due_date, remind_at, status, priority,
+                                    created_at, completed_at, order_index, pinned, repeat,
+                                    subtasks, updated_at, deleted_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                 ON CONFLICT(id) DO UPDATE SET
+                    title = excluded.title, notes = excluded.notes, due_date = excluded.due_date,
+                    remind_at = excluded.remind_at, status = excluded.status,
+                    priority = excluded.priority, completed_at = excluded.completed_at,
+                    order_index = excluded.order_index, pinned = excluded.pinned,
+                    repeat = excluded.repeat, subtasks = excluded.subtasks,
+                    updated_at = excluded.updated_at, deleted_at = excluded.deleted_at",
+                params![
+                    t.id,
+                    t.title,
+                    t.notes,
+                    t.due_date,
+                    t.remind_at,
+                    t.status,
+                    t.priority,
+                    t.created_at,
+                    t.completed_at,
+                    t.order_index,
+                    t.pinned as i64,
+                    t.repeat,
+                    t.subtasks.to_string(),
+                    t.updated_at,
+                    t.deleted_at,
+                ],
+            )?;
+        }
+    }
+
+    for tl in &remote.task_labels {
+        let local = local_updated_at(
+            conn,
+            "SELECT updated_at FROM task_labels WHERE task_id = ?1 AND label_id = ?2",
+            &[&tl.task_id, &tl.label_id],
+        );
+        if local.as_deref().map(|cur| newer(&tl.updated_at, cur)).unwrap_or(true) {
+            conn.execute(
+                "INSERT INTO task_labels (task_id, label_id, updated_at, deleted_at)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(task_id, label_id) DO UPDATE SET
+                    updated_at = excluded.updated_at, deleted_at = excluded.deleted_at",
+                params![tl.task_id, tl.label_id, tl.updated_at, tl.deleted_at],
+            )?;
+        }
+    }
+
+    for s in &remote.sessions {
+        let local =
+            local_updated_at(conn, "SELECT updated_at FROM time_sessions WHERE id = ?1", &[&s.id]);
+        if local.as_deref().map(|cur| newer(&s.updated_at, cur)).unwrap_or(true) {
+            conn.execute(
+                "INSERT INTO time_sessions (id, task_id, start_at, end_at, seconds, notified,
+                                            updated_at, deleted_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7)
+                 ON CONFLICT(id) DO UPDATE SET
+                    task_id = excluded.task_id, start_at = excluded.start_at,
+                    end_at = excluded.end_at, seconds = excluded.seconds,
+                    updated_at = excluded.updated_at, deleted_at = excluded.deleted_at",
+                params![s.id, s.task_id, s.start_at, s.end_at, s.seconds, s.updated_at, s.deleted_at],
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+// ------------------------------------------------------------------- watermark
+
+/// The high-water mark: local rows changed at or before this were last synced.
+#[tauri::command]
+pub fn sync_get_watermark(db: State<Db>) -> Result<String, String> {
+    Ok(settings::read(&db.conn(), WATERMARK_KEY).unwrap_or_else(|| EPOCH.to_string()))
+}
+
+#[tauri::command]
+pub fn sync_set_watermark(db: State<Db>, value: String) -> Result<(), String> {
+    settings::write(&db.conn(), WATERMARK_KEY, &value).map_err(|e| e.to_string())
+}
+
+/// Forget the watermark so the next round re-pulls and re-pushes everything —
+/// used when a different account signs in on this device.
+#[tauri::command]
+pub fn sync_reset(db: State<Db>) -> Result<(), String> {
+    settings::write(&db.conn(), WATERMARK_KEY, EPOCH).map_err(|e| e.to_string())
+}
+
+/// Hard-delete tombstones whose `deleted_at` is older than `days`. By then the
+/// deletion has long since propagated, so keeping the row only wastes space.
+/// Compared as parsed instants against a cutoff, so mixed offsets are fine.
+#[tauri::command]
+pub fn sync_purge_tombstones(db: State<Db>, days: i64) -> Result<(), String> {
+    purge_tombstones(&db.conn(), days).map_err(|e| e.to_string())
+}
+
+fn purge_tombstones(conn: &Connection, days: i64) -> rusqlite::Result<()> {
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(days.max(0));
+    // Children before parents; deleting a task also cascades any leftovers.
+    for table in ["task_labels", "time_sessions", "tasks", "labels"] {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT rowid, deleted_at FROM {table} WHERE deleted_at IS NOT NULL"
+        ))?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (rowid, deleted_at) in rows {
+            let expired = DateTime::parse_from_rfc3339(&deleted_at)
+                .map(|d| d.with_timezone(&chrono::Utc) < cutoff)
+                .unwrap_or(false);
+            if expired {
+                conn.execute(&format!("DELETE FROM {table} WHERE rowid = ?1"), [rowid])?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        db::init(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn apply_inserts_then_lww_updates() {
+        let conn = setup();
+        let bundle = SyncBundle {
+            labels: vec![SyncLabel {
+                id: "l1".into(),
+                name: "home".into(),
+                color: "#fff".into(),
+                updated_at: "2026-01-01T00:00:00+00:00".into(),
+                deleted_at: None,
+            }],
+            tasks: vec![SyncTask {
+                id: "t1".into(),
+                title: "milk".into(),
+                notes: None,
+                due_date: None,
+                remind_at: None,
+                status: "active".into(),
+                priority: 4,
+                created_at: "2026-01-01T00:00:00+00:00".into(),
+                completed_at: None,
+                order_index: 1.0,
+                pinned: false,
+                repeat: None,
+                subtasks: serde_json::json!([]),
+                updated_at: "2026-01-01T00:00:00+00:00".into(),
+                deleted_at: None,
+            }],
+            task_labels: vec![SyncTaskLabel {
+                task_id: "t1".into(),
+                label_id: "l1".into(),
+                updated_at: "2026-01-01T00:00:00+00:00".into(),
+                deleted_at: None,
+            }],
+            sessions: vec![],
+        };
+        apply_bundle(&conn, &bundle).unwrap();
+
+        let title: String = conn
+            .query_row("SELECT title FROM tasks WHERE id = 't1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "milk");
+
+        // An older remote edit is ignored.
+        let mut older = bundle;
+        older.tasks[0].title = "STALE".into();
+        older.tasks[0].updated_at = "2025-01-01T00:00:00+00:00".into();
+        apply_bundle(&conn, &older).unwrap();
+        let title: String = conn
+            .query_row("SELECT title FROM tasks WHERE id = 't1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "milk");
+
+        // A newer remote edit wins, even across a different UTC offset.
+        let newer_bundle = SyncBundle {
+            tasks: vec![SyncTask {
+                id: "t1".into(),
+                title: "oat milk".into(),
+                notes: None,
+                due_date: None,
+                remind_at: None,
+                status: "active".into(),
+                priority: 4,
+                created_at: "2026-01-01T00:00:00+00:00".into(),
+                completed_at: None,
+                order_index: 1.0,
+                pinned: true,
+                repeat: None,
+                subtasks: serde_json::json!([{"id":1,"text":"a","done":false}]),
+                updated_at: "2026-06-01T05:00:00+05:00".into(),
+                deleted_at: None,
+            }],
+            ..Default::default()
+        };
+        apply_bundle(&conn, &newer_bundle).unwrap();
+        let (title, pinned): (String, i64) = conn
+            .query_row("SELECT title, pinned FROM tasks WHERE id = 't1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(title, "oat milk");
+        assert_eq!(pinned, 1);
+    }
+
+    #[test]
+    fn changes_since_respects_watermark_and_tombstones() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO labels (id, name, color, updated_at, deleted_at)
+             VALUES ('old', 'x', '#000', '2025-01-01T00:00:00+00:00', NULL),
+                    ('new', 'y', '#111', '2026-05-01T00:00:00+00:00', '2026-05-02T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+
+        let bundle = collect_changes(&conn, "2026-01-01T00:00:00+00:00").unwrap();
+        assert_eq!(bundle.labels.len(), 1);
+        assert_eq!(bundle.labels[0].id, "new");
+        // The tombstone travels so the deletion can propagate.
+        assert!(bundle.labels[0].deleted_at.is_some());
+    }
+
+    #[test]
+    fn purge_drops_only_old_tombstones() {
+        let conn = setup();
+        let recent = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO labels (id, name, color, updated_at, deleted_at) VALUES
+                ('live', 'a', '#000', ?1, NULL),
+                ('fresh_del', 'b', '#000', ?1, ?1),
+                ('old_del', 'c', '#000', '2020-01-01T00:00:00+00:00', '2020-01-01T00:00:00+00:00')",
+            [recent],
+        )
+        .unwrap();
+
+        purge_tombstones(&conn, 30).unwrap();
+
+        let ids: Vec<String> = {
+            let mut stmt = conn.prepare("SELECT id FROM labels ORDER BY id").unwrap();
+            stmt.query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<rusqlite::Result<_>>()
+                .unwrap()
+        };
+        // Live row and the recent tombstone stay; only the long-dead one goes.
+        assert_eq!(ids, vec!["fresh_del", "live"]);
+    }
+}

--- a/src-tauri/src/timer.rs
+++ b/src-tauri/src/timer.rs
@@ -9,7 +9,7 @@
 //!   current phase is `accumulated + (now - start_at)` while running, capped
 //!   the same way if left running past `MAX_SESSION_SECS`.
 
-use crate::db::Db;
+use crate::db::{new_uuid, Db};
 use crate::models::{ActiveTimer, Pomodoro, SessionLog};
 use chrono::{DateTime, Local};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -40,13 +40,13 @@ fn close_stale_sessions(conn: &Connection) -> rusqlite::Result<()> {
     let now = now_iso();
     let mut stmt =
         conn.prepare("SELECT id, start_at FROM time_sessions WHERE end_at IS NULL")?;
-    let rows: Vec<(i64, String)> = stmt
+    let rows: Vec<(String, String)> = stmt
         .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
         .collect::<rusqlite::Result<_>>()?;
     for (id, start) in rows {
         if secs_since(&start) > MAX_SESSION_SECS {
             conn.execute(
-                "UPDATE time_sessions SET end_at = ?1, seconds = ?2 WHERE id = ?3",
+                "UPDATE time_sessions SET end_at = ?1, seconds = ?2, updated_at = ?1 WHERE id = ?3",
                 params![now, MAX_SESSION_SECS, id],
             )?;
         }
@@ -59,8 +59,8 @@ fn read_active(conn: &Connection) -> rusqlite::Result<Option<ActiveTimer>> {
     conn.query_row(
         "SELECT s.task_id, t.title, s.start_at
          FROM time_sessions s JOIN tasks t ON t.id = s.task_id
-         WHERE s.end_at IS NULL
-         ORDER BY s.id DESC LIMIT 1",
+         WHERE s.end_at IS NULL AND s.deleted_at IS NULL AND t.deleted_at IS NULL
+         ORDER BY s.start_at DESC LIMIT 1",
         [],
         |r| {
             Ok(ActiveTimer {
@@ -77,12 +77,12 @@ fn read_active(conn: &Connection) -> rusqlite::Result<Option<ActiveTimer>> {
 fn close_open_sessions(conn: &Connection) -> rusqlite::Result<()> {
     let now = now_iso();
     let mut stmt = conn.prepare("SELECT id, start_at FROM time_sessions WHERE end_at IS NULL")?;
-    let rows: Vec<(i64, String)> = stmt
+    let rows: Vec<(String, String)> = stmt
         .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
         .collect::<rusqlite::Result<_>>()?;
     for (id, start) in rows {
         conn.execute(
-            "UPDATE time_sessions SET end_at = ?1, seconds = ?2 WHERE id = ?3",
+            "UPDATE time_sessions SET end_at = ?1, seconds = ?2, updated_at = ?1 WHERE id = ?3",
             params![now, secs_since(&start), id],
         )?;
     }
@@ -92,12 +92,12 @@ fn close_open_sessions(conn: &Connection) -> rusqlite::Result<()> {
 /// Start tracking a task. Any other running session is stopped first, so at
 /// most one stopwatch runs at a time.
 #[tauri::command]
-pub fn start_timer(db: State<Db>, id: i64) -> Result<Option<ActiveTimer>, String> {
+pub fn start_timer(db: State<Db>, id: String) -> Result<Option<ActiveTimer>, String> {
     let conn = db.conn();
     close_open_sessions(&conn).map_err(|e| e.to_string())?;
     conn.execute(
-        "INSERT INTO time_sessions (task_id, start_at) VALUES (?1, ?2)",
-        params![id, now_iso()],
+        "INSERT INTO time_sessions (id, task_id, start_at, updated_at) VALUES (?1, ?2, ?3, ?3)",
+        params![new_uuid(), id, now_iso()],
     )
     .map_err(|e| e.to_string())?;
     read_active(&conn).map_err(|e| e.to_string())
@@ -122,7 +122,7 @@ pub fn focus_history(db: State<Db>, limit: i64) -> Result<Vec<SessionLog>, Strin
         .prepare(
             "SELECT s.id, s.task_id, t.title, s.start_at, s.end_at, s.seconds
              FROM time_sessions s JOIN tasks t ON t.id = s.task_id
-             WHERE s.end_at IS NOT NULL
+             WHERE s.end_at IS NOT NULL AND s.deleted_at IS NULL AND t.deleted_at IS NULL
              ORDER BY s.start_at DESC LIMIT ?1",
         )
         .map_err(|e| e.to_string())?;
@@ -300,67 +300,80 @@ pub fn set_pomodoro_config(
 /// stopping either timer.
 pub fn poll(app: &AppHandle, notifications_enabled: bool) {
     let db = app.state::<Db>();
-    let conn = db.conn();
     let mut pomodoro_changed = false;
 
-    // Enforce the runaway-timer safety cap even if nobody's looking at the UI.
-    let _ = close_stale_sessions(&conn);
-    let _ = close_stale_pomodoro(&conn);
+    // Pending reminders, gathered while the DB lock is held and delivered
+    // only after it's released — `notify::send` can make a blocking D-Bus
+    // call, and holding the mutex across that would freeze every other
+    // command (they all need `db.conn()`) if the portal is slow to reply.
+    let mut pomodoro_notice: Option<(&'static str, &'static str)> = None;
+    let mut stopwatch_notices: Vec<(i64, String, String)> = Vec::new();
 
-    // Pomodoro phase reached its target — nudge once, keep running (overtime).
-    if let Ok(p) = read_pomodoro(&conn) {
-        if p.running {
-            let elapsed = p.accumulated + p.start_at.as_deref().map(secs_since).unwrap_or(0);
-            let notified: i64 = conn
-                .query_row("SELECT notified FROM pomodoro WHERE id = 1", [], |r| {
-                    r.get(0)
-                })
-                .unwrap_or(0);
-            if elapsed >= p.target && notified == 0 {
-                let (title, body) = if p.phase == "focus" {
-                    ("Focus session done", "Time for a break · todofy")
-                } else {
-                    ("Break's over", "Back to focus · todofy")
-                };
-                if notifications_enabled {
-                    crate::notify::send(app, title, body, None);
+    {
+        let conn = db.conn();
+
+        // Enforce the runaway-timer safety cap even if nobody's looking at the UI.
+        let _ = close_stale_sessions(&conn);
+        let _ = close_stale_pomodoro(&conn);
+
+        // Pomodoro phase reached its target — nudge once, keep running (overtime).
+        if let Ok(p) = read_pomodoro(&conn) {
+            if p.running {
+                let elapsed = p.accumulated + p.start_at.as_deref().map(secs_since).unwrap_or(0);
+                let notified: i64 = conn
+                    .query_row("SELECT notified FROM pomodoro WHERE id = 1", [], |r| {
+                        r.get(0)
+                    })
+                    .unwrap_or(0);
+                if elapsed >= p.target && notified == 0 {
+                    pomodoro_notice = Some(if p.phase == "focus" {
+                        ("Focus session done", "Time for a break · todofy")
+                    } else {
+                        ("Break's over", "Back to focus · todofy")
+                    });
+                    let _ = conn.execute("UPDATE pomodoro SET notified = 1 WHERE id = 1", []);
+                    pomodoro_changed = true;
                 }
-                let _ = conn.execute("UPDATE pomodoro SET notified = 1 WHERE id = 1", []);
-                pomodoro_changed = true;
             }
         }
-    }
 
-    // Long-running stopwatch: nudge once per elapsed hour, keep it running.
-    if let Ok(mut stmt) = conn.prepare(
-        "SELECT s.id, t.title, s.start_at, s.notified
-         FROM time_sessions s JOIN tasks t ON t.id = s.task_id
-         WHERE s.end_at IS NULL",
-    ) {
-        let rows: Vec<(i64, String, String, i64)> = stmt
-            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
-            .and_then(|it| it.collect())
-            .unwrap_or_default();
-        for (id, title, start, notified) in rows {
-            let hours = secs_since(&start) / 3600;
-            if hours > notified {
-                if notifications_enabled {
-                    crate::notify::send(
-                        app,
-                        "Still tracking time",
-                        &format!("“{title}” — {hours}h and counting · todofy"),
-                        None,
+        // Long-running stopwatch: nudge once per elapsed hour, keep it running.
+        if let Ok(mut stmt) = conn.prepare(
+            "SELECT s.id, t.title, s.start_at, s.notified
+             FROM time_sessions s JOIN tasks t ON t.id = s.task_id
+             WHERE s.end_at IS NULL AND s.deleted_at IS NULL AND t.deleted_at IS NULL",
+        ) {
+            let rows: Vec<(String, String, String, i64)> = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+                .and_then(|it| it.collect())
+                .unwrap_or_default();
+            for (id, title, start, notified) in rows {
+                let hours = secs_since(&start) / 3600;
+                if hours > notified {
+                    let _ = conn.execute(
+                        "UPDATE time_sessions SET notified = ?1 WHERE id = ?2",
+                        params![hours, id],
                     );
+                    stopwatch_notices.push((hours, title, id));
                 }
-                let _ = conn.execute(
-                    "UPDATE time_sessions SET notified = ?1 WHERE id = ?2",
-                    params![hours, id],
-                );
             }
+        };
+    } // conn dropped here — lock released before any notification is sent
+
+    if notifications_enabled {
+        if let Some((title, body)) = pomodoro_notice {
+            crate::notify::send(app, title, body, None);
+        }
+        for (hours, title, _id) in &stopwatch_notices {
+            crate::notify::send(
+                app,
+                "Still tracking time",
+                &format!("“{title}” — {hours}h and counting · todofy"),
+                None,
+            );
         }
     }
 
-    drop(conn);
     if pomodoro_changed {
         let _ = app.emit("pomodoro-updated", ());
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "todofy",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "com.unifybrowse.todofy",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,12 @@ import {
 } from "@tauri-apps/plugin-notification";
 import { listen } from "@tauri-apps/api/event";
 import { activeCount, useStore } from "./store";
+import { useAuth } from "./lib/auth";
+import { initSync } from "./lib/sync";
 import { applyTheme } from "./lib/theme";
 import { useKeyboard } from "./lib/useKeyboard";
 import type { ActiveReminder } from "./types";
+import { ContextMenu, type MenuItem } from "./components/ContextMenu";
 import { Sidebar } from "./components/Sidebar";
 import { TaskList } from "./components/TaskList";
 import { TaskDetail } from "./components/TaskDetail";
@@ -30,12 +33,35 @@ export function App() {
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const selectedId = useStore((s) => s.selectedId);
   const select = useStore((s) => s.select);
+  const setView = useStore((s) => s.setView);
+  const toggleTheme = useStore((s) => s.toggleTheme);
+
+  const menuActions = (): MenuItem[] => [
+    {
+      label: "New task",
+      onClick: () => {
+        setView({ kind: "today" });
+        requestAnimationFrame(() =>
+          document.getElementById("quick-add-input")?.focus(),
+        );
+      },
+    },
+    { label: "Settings", onClick: () => setView({ kind: "settings" }) },
+    {
+      label: theme === "dark" ? "Light theme" : "Dark theme",
+      onClick: toggleTheme,
+    },
+  ];
 
   useKeyboard();
 
   useEffect(() => {
     load();
     loadTimers();
+    // Restore any saved Supabase session and watch for auth changes.
+    useAuth.getState().init();
+    // Wire account sync (runs on sign-in, then periodically + after edits).
+    initSync();
     // Ask for desktop notification permission once, up front.
     (async () => {
       if (!(await isPermissionGranted())) {
@@ -48,7 +74,7 @@ export function App() {
       pushReminder(e.payload);
     });
     // The custom notification popup was clicked — jump to that task.
-    const unOpen = listen<number>("reminder-open", (e) => {
+    const unOpen = listen<string>("reminder-open", (e) => {
       useStore.getState().select(e.payload);
     });
     // Refresh when a task is added from the quick-add window.
@@ -113,6 +139,7 @@ export function App() {
       <ConfirmDialog />
       <ShortcutsOverlay />
       <Celebration />
+      <ContextMenu appItems={menuActions} />
     </div>
   );
 }

--- a/src/components/AccountSection.tsx
+++ b/src/components/AccountSection.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useState } from "preact/hooks";
+import { useAuth } from "../lib/auth";
+import { useSync, type SyncStatus } from "../lib/sync";
+import { CloseIcon, UserIcon } from "./Icons";
+
+type Mode = "signin" | "signup";
+
+export function AccountSection() {
+  const { ready, session, email, signIn, signUp, signOut } = useAuth();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <section class="mb-6">
+      <h3 class="mb-2 px-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">
+        Account
+      </h3>
+      <div class="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+        {!ready ? (
+          <div class="px-4 py-3.5 text-sm text-[var(--color-muted)]">Loading…</div>
+        ) : session ? (
+          <SignedInRow email={email} onSignOut={signOut} />
+        ) : (
+          <SignInRow onSignIn={() => setModalOpen(true)} />
+        )}
+      </div>
+
+      {modalOpen && (
+        <AuthModal
+          signIn={signIn}
+          signUp={signUp}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </section>
+  );
+}
+
+function SignInRow({ onSignIn }: { onSignIn: () => void }) {
+  return (
+    <div class="flex items-center gap-3 px-4 py-3.5">
+      <span class="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-[var(--color-surface-2)] text-[var(--color-muted)]">
+        <UserIcon width={18} height={18} />
+      </span>
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-medium text-[var(--color-text)]">
+          Sign in to sync
+        </p>
+        <p class="mt-0.5 text-xs text-[var(--color-muted)]">
+          Keep your tasks in sync across all your devices.
+        </p>
+      </div>
+      <button
+        onClick={onSignIn}
+        class="shrink-0 rounded-lg bg-[var(--color-accent)] px-3.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[var(--color-accent-hover)]"
+      >
+        Sign in
+      </button>
+    </div>
+  );
+}
+
+function SignedInRow({
+  email,
+  onSignOut,
+}: {
+  email: string | null;
+  onSignOut: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  return (
+    <>
+      <div class="flex items-center gap-3 px-4 py-3.5">
+        <span class="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-[var(--color-surface-2)] text-[var(--color-muted)]">
+          <UserIcon width={18} height={18} />
+        </span>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-medium text-[var(--color-text)]">
+            {email ?? "Signed in"}
+          </p>
+          <p class="mt-0.5 text-xs text-[var(--color-muted)]">
+            Signed in — your tasks are linked to this account.
+          </p>
+        </div>
+        <button
+          onClick={async () => {
+            setBusy(true);
+            try {
+              await onSignOut();
+            } finally {
+              setBusy(false);
+            }
+          }}
+          disabled={busy}
+          class="shrink-0 rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] disabled:opacity-50"
+        >
+          {busy ? "Signing out…" : "Sign out"}
+        </button>
+      </div>
+      <SyncStatusRow />
+    </>
+  );
+}
+
+const STATUS_META: Record<SyncStatus, { dot: string; label: string }> = {
+  idle: { dot: "bg-[var(--color-success)]", label: "Synced" },
+  syncing: { dot: "bg-[var(--color-warning)]", label: "Syncing…" },
+  offline: { dot: "bg-[var(--color-faint)]", label: "Offline — will retry" },
+  error: { dot: "bg-[var(--color-danger)]", label: "Sync failed" },
+};
+
+function SyncStatusRow() {
+  const { status, lastSyncedAt, error, syncNow } = useSync();
+  const meta = STATUS_META[status];
+  const detail =
+    status === "error"
+      ? error ?? "Something went wrong."
+      : status === "idle" && !lastSyncedAt
+        ? "Not synced yet"
+        : lastSyncedAt
+          ? `Last synced ${relativeTime(lastSyncedAt)}`
+          : "";
+
+  return (
+    <div class="flex items-center gap-3 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
+      <span class={`h-2 w-2 shrink-0 rounded-full ${meta.dot}`} />
+      <div class="min-w-0 flex-1">
+        <p class="text-xs font-medium text-[var(--color-text)]">{meta.label}</p>
+        {detail && (
+          <p class="mt-0.5 truncate text-[11px] text-[var(--color-muted)]">{detail}</p>
+        )}
+      </div>
+      <button
+        onClick={() => void syncNow()}
+        disabled={status === "syncing"}
+        class="shrink-0 rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] disabled:opacity-50"
+      >
+        {status === "syncing" ? "Syncing…" : "Sync now"}
+      </button>
+    </div>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const secs = Math.max(0, Math.floor((Date.now() - Date.parse(iso)) / 1000));
+  if (secs < 10) return "just now";
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function AuthModal({
+  signIn,
+  signUp,
+  onClose,
+}: {
+  signIn: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>;
+  signUp: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>;
+  onClose: () => void;
+}) {
+  const [mode, setMode] = useState<Mode>("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const submit = async (e: Event) => {
+    e.preventDefault();
+    if (busy) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const run = mode === "signin" ? signIn : signUp;
+      const result = await run(email, password);
+      if (result.ok) onClose();
+      else setError(result.error ?? "Something went wrong.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const signup = mode === "signup";
+
+  return (
+    <div
+      class="fixed inset-0 z-[100] grid place-items-center bg-black/50 p-4 backdrop-blur-sm"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div class="relative w-full max-w-sm animate-fade-rise overflow-hidden rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] shadow-2xl shadow-black/50">
+        <button
+          onClick={onClose}
+          title="Close"
+          class="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full text-[var(--color-faint)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
+        >
+          <CloseIcon width={16} height={16} />
+        </button>
+
+        <div class="flex flex-col items-center gap-2 px-6 pt-8 pb-2 text-center">
+          <span class="grid h-12 w-12 place-items-center rounded-2xl bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+            <UserIcon width={24} height={24} />
+          </span>
+          <h3 class="text-lg font-semibold text-[var(--color-text)]">
+            {signup ? "Create your account" : "Welcome back"}
+          </h3>
+          <p class="text-xs text-[var(--color-muted)]">
+            {signup
+              ? "Sync your tasks across all your devices."
+              : "Sign in to sync your tasks across devices."}
+          </p>
+        </div>
+
+        <form onSubmit={submit} class="flex flex-col gap-3 px-6 pt-3 pb-6">
+          <Field
+            label="Email"
+            type="email"
+            value={email}
+            autocomplete="email"
+            placeholder="you@example.com"
+            onInput={setEmail}
+          />
+          <Field
+            label="Password"
+            type="password"
+            value={password}
+            autocomplete={signup ? "new-password" : "current-password"}
+            placeholder={signup ? "At least 6 characters" : "••••••••"}
+            onInput={setPassword}
+          />
+
+          {error && (
+            <p class="rounded-lg bg-[var(--color-danger)]/10 px-3 py-2 text-xs text-[var(--color-danger)]">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={busy || !email || !password}
+            class="mt-1 rounded-lg bg-[var(--color-accent)] px-3 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+          >
+            {busy
+              ? signup
+                ? "Creating account…"
+                : "Signing in…"
+              : signup
+                ? "Create account"
+                : "Sign in"}
+          </button>
+        </form>
+
+        <div class="border-t border-[var(--color-border)] px-6 py-3.5 text-center">
+          <button
+            type="button"
+            onClick={() => {
+              setMode(signup ? "signin" : "signup");
+              setError(null);
+            }}
+            class="text-xs text-[var(--color-muted)] transition-colors hover:text-[var(--color-text)]"
+          >
+            {signup ? (
+              <>
+                Already have an account?{" "}
+                <span class="font-medium text-[var(--color-accent)]">Sign in</span>
+              </>
+            ) : (
+              <>
+                New to todofy?{" "}
+                <span class="font-medium text-[var(--color-accent)]">
+                  Create an account
+                </span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  type,
+  value,
+  placeholder,
+  autocomplete,
+  onInput,
+}: {
+  label: string;
+  type: string;
+  value: string;
+  placeholder?: string;
+  autocomplete?: string;
+  onInput: (value: string) => void;
+}) {
+  return (
+    <label class="flex flex-col gap-1 text-left">
+      <span class="text-[10px] font-medium uppercase tracking-wider text-[var(--color-faint)]">
+        {label}
+      </span>
+      <input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        autocomplete={autocomplete}
+        onInput={(e) => onInput(e.currentTarget.value)}
+        class="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--color-accent)]"
+      />
+    </label>
+  );
+}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+
+export interface MenuItem {
+  label: string;
+  onClick: () => void;
+  hint?: string;
+  danger?: boolean;
+}
+
+type Entry = MenuItem | "divider";
+
+/** App-specific actions appended below the editing items, per window. */
+type AppItems = () => MenuItem[];
+
+/**
+ * todofy's own right-click menu, replacing the webview's browser menu (Back /
+ * Forward / Reload / Inspect Element). Mount one per window; it captures every
+ * `contextmenu`, offers context-aware Cut / Copy / Paste / Select all on text,
+ * and any app actions the window passes in.
+ */
+export function ContextMenu({ appItems }: { appItems?: AppItems }) {
+  const [menu, setMenu] = useState<{ x: number; y: number; items: Entry[] } | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onContext = (e: MouseEvent) => {
+      e.preventDefault();
+      const items = buildItems(e.target, appItems?.() ?? []);
+      setMenu(items.length ? { x: e.clientX, y: e.clientY, items } : null);
+    };
+    const close = () => setMenu(null);
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setMenu(null);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setMenu(null);
+
+    document.addEventListener("contextmenu", onContext);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("contextmenu", onContext);
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [appItems]);
+
+  // Keep the menu fully on screen, measured after it renders.
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  useLayoutEffect(() => {
+    if (!menu || !ref.current) {
+      setPos(null);
+      return;
+    }
+    const r = ref.current.getBoundingClientRect();
+    const gap = 6;
+    const left = Math.min(menu.x, window.innerWidth - r.width - gap);
+    const top = Math.min(menu.y, window.innerHeight - r.height - gap);
+    setPos({ left: Math.max(gap, left), top: Math.max(gap, top) });
+  }, [menu]);
+
+  if (!menu) return null;
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        left: pos ? pos.left : menu.x,
+        top: pos ? pos.top : menu.y,
+        visibility: pos ? "visible" : "hidden",
+      }}
+      class="fixed z-[200] min-w-[190px] animate-fade-rise overflow-hidden rounded-xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] p-1 shadow-2xl shadow-black/50"
+    >
+      {menu.items.map((item, i) =>
+        item === "divider" ? (
+          <div key={i} class="my-1 h-px bg-[var(--color-border)]" />
+        ) : (
+          <button
+            key={i}
+            onClick={() => {
+              setMenu(null);
+              item.onClick();
+            }}
+            class={`flex w-full items-center justify-between gap-6 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
+              item.danger
+                ? "text-[var(--color-danger)] hover:bg-[var(--color-danger)]/12"
+                : "text-[var(--color-text)] hover:bg-[var(--color-surface-2)]"
+            }`}
+          >
+            <span>{item.label}</span>
+            {item.hint && (
+              <span class="text-xs text-[var(--color-faint)]">{item.hint}</span>
+            )}
+          </button>
+        ),
+      )}
+    </div>
+  );
+}
+
+function buildItems(target: EventTarget | null, appItems: MenuItem[]): Entry[] {
+  const items: Entry[] = [];
+  const field = fieldOf(target);
+  const selected = field
+    ? field.value.slice(field.selectionStart ?? 0, field.selectionEnd ?? 0)
+    : window.getSelection()?.toString() ?? "";
+
+  if (field && selected)
+    items.push({
+      label: "Cut",
+      hint: "Ctrl+X",
+      onClick: () => {
+        writeClipboard(selected);
+        replaceSelection(field, "");
+      },
+    });
+  if (selected)
+    items.push({ label: "Copy", hint: "Ctrl+C", onClick: () => writeClipboard(selected) });
+  if (field)
+    items.push({
+      label: "Paste",
+      hint: "Ctrl+V",
+      onClick: async () => replaceSelection(field, await readClipboard()),
+    });
+  if (field)
+    items.push({ label: "Select all", hint: "Ctrl+A", onClick: () => field.select() });
+
+  if (appItems.length) {
+    if (items.length) items.push("divider");
+    items.push(...appItems);
+  }
+  return items;
+}
+
+function fieldOf(target: EventTarget | null): HTMLInputElement | HTMLTextAreaElement | null {
+  const el = target instanceof HTMLElement ? target.closest("input, textarea") : null;
+  return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement ? el : null;
+}
+
+async function writeClipboard(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    /* clipboard unavailable — ignore */
+  }
+}
+
+async function readClipboard(): Promise<string> {
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    return "";
+  }
+}
+
+/** Replace the field's current selection with `text` and fire an input event so
+ *  a controlled Preact input picks up the change. */
+function replaceSelection(field: HTMLInputElement | HTMLTextAreaElement, text: string) {
+  const start = field.selectionStart ?? field.value.length;
+  const end = field.selectionEnd ?? field.value.length;
+  field.value = field.value.slice(0, start) + text + field.value.slice(end);
+  const caret = start + text.length;
+  field.setSelectionRange(caret, caret);
+  field.dispatchEvent(new Event("input", { bubbles: true }));
+  field.focus();
+}

--- a/src/components/FocusWidget.tsx
+++ b/src/components/FocusWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { useStore } from "../store";
 import type { PomodoroPhase } from "../types";
 import { clock, formatDuration, secondsSince } from "../lib/duration";
@@ -42,6 +42,20 @@ export function FocusWidget() {
     return () => clearInterval(i);
   }, [pomodoro?.running, activeTimer]);
 
+  // Click anywhere outside the card closes it, same as the ✕ button.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!showFocus) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (rootRef.current?.contains(target)) return;
+      if (target instanceof Element && target.closest("[data-focus-toggle]")) return;
+      toggleFocus();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [showFocus, toggleFocus]);
+
   if (!showFocus) return null;
 
   const p = pomodoro;
@@ -53,7 +67,10 @@ export function FocusWidget() {
   const activeElapsed = activeTimer ? secondsSince(activeTimer.startAt) : 0;
 
   return (
-    <div class="fixed bottom-4 left-4 z-50 w-72 animate-fade-rise overflow-hidden rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] shadow-2xl shadow-black/50">
+    <div
+      ref={rootRef}
+      class="fixed bottom-4 left-4 z-50 w-72 animate-fade-rise overflow-hidden rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] shadow-2xl shadow-black/50"
+    >
       {/* Header */}
       <div class="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2.5">
         <span class="text-xs font-semibold uppercase tracking-wider text-[var(--color-faint)]">

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -21,6 +21,13 @@ export const InboxIcon = (p: P) => (
   </svg>
 );
 
+export const UserIcon = (p: P) => (
+  <svg {...base(p)}>
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
 export const TodayIcon = (p: P) => (
   <svg {...base(p)}>
     <rect x="3" y="4" width="18" height="18" rx="2" />

--- a/src/components/LabelsView.tsx
+++ b/src/components/LabelsView.tsx
@@ -9,7 +9,7 @@ export function LabelsView() {
     useStore();
   const [query, setQuery] = useState("");
   const [adding, setAdding] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   const filtered = labels.filter((l) =>
     l.name.toLowerCase().includes(query.trim().toLowerCase()),

--- a/src/components/NotificationPopup.tsx
+++ b/src/components/NotificationPopup.tsx
@@ -3,25 +3,24 @@ import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { BellIcon, CloseIcon } from "./Icons";
 
-/** Payload pushed from the Rust `popup::show` (serde snake_case). */
 interface NotifyPayload {
   nonce: number;
   title: string;
   body: string;
-  task_id: number | null;
+  task_id: string | null;
 }
 
-/** How long a notification stays before it auto-dismisses. */
 const AUTO_DISMISS_MS = 6000;
 
 /**
- * The corner notification popup. Lives in its own transparent, always-on-top,
- * non-focusing Tauri window (`notification`). The backend positions the window
- * in the chosen screen corner and emits `notify-show`; this renders the card and
- * dismisses itself after a timeout (paused while hovered).
+ * The corner notification popup, in its own transparent, always-on-top Tauri
+ * window. The backend positions it and pushes the content; this renders the
+ * card and dismisses after a timeout (paused while hovered).
  */
 export function NotificationPopup() {
   const [note, setNote] = useState<NotifyPayload | null>(null);
+  const [paused, setPaused] = useState(false);
+  const [cycle, setCycle] = useState(0);
   const timer = useRef<number | undefined>(undefined);
 
   const clearTimer = () => {
@@ -33,7 +32,14 @@ export function NotificationPopup() {
 
   const startTimer = () => {
     clearTimer();
+    setPaused(false);
+    setCycle((c) => c + 1);
     timer.current = window.setTimeout(dismiss, AUTO_DISMISS_MS);
+  };
+
+  const pause = () => {
+    clearTimer();
+    setPaused(true);
   };
 
   const dismiss = () => {
@@ -54,6 +60,15 @@ export function NotificationPopup() {
       setNote(e.payload);
       startTimer();
     });
+    // Catch a notification shown before this webview finished loading.
+    invoke<NotifyPayload | null>("notify_popup_pending")
+      .then((pending) => {
+        if (pending) {
+          setNote(pending);
+          startTimer();
+        }
+      })
+      .catch(() => {});
     return () => {
       unlisten.then((off) => off());
       clearTimer();
@@ -66,32 +81,44 @@ export function NotificationPopup() {
     <div class="flex h-screen w-screen items-stretch p-2">
       <div
         key={note.nonce}
-        onMouseEnter={clearTimer}
+        onMouseEnter={pause}
         onMouseLeave={startTimer}
         onClick={open}
-        class="group flex w-full animate-slide-left cursor-pointer items-start gap-3 rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] p-3.5 shadow-xl shadow-black/40"
+        class="group relative flex w-full animate-slide-left cursor-pointer overflow-hidden rounded-2xl border border-[var(--color-border-strong)] bg-[var(--color-elevated)] shadow-2xl shadow-black/50 ring-1 ring-white/5"
       >
-        <span class="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
-          <BellIcon width={18} height={18} />
-        </span>
-        <div class="min-w-0 flex-1">
-          <p class="truncate text-sm font-semibold text-[var(--color-text)]">
-            {note.title}
-          </p>
-          <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-muted)]">
-            {note.body}
-          </p>
+        <div class="flex flex-1 items-start gap-3 p-3.5">
+          <span class="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-[var(--color-accent-soft)] text-[var(--color-accent)] ring-1 ring-inset ring-[var(--color-accent)]/25">
+            <BellIcon width={19} height={19} />
+          </span>
+          <div class="min-w-0 flex-1 pr-5">
+            <p class="truncate text-sm font-semibold text-[var(--color-text)]">
+              {note.title}
+            </p>
+            <p class="mt-0.5 line-clamp-2 text-xs leading-relaxed text-[var(--color-muted)]">
+              {note.body}
+            </p>
+          </div>
         </div>
+
         <button
           onClick={(e) => {
             e.stopPropagation();
             dismiss();
           }}
           title="Dismiss"
-          class="shrink-0 rounded-lg p-1 text-[var(--color-faint)] opacity-0 transition-opacity hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] group-hover:opacity-100"
+          class="absolute right-2 top-2 grid h-6 w-6 place-items-center rounded-lg text-[var(--color-faint)] opacity-0 transition-opacity hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] group-hover:opacity-100"
         >
-          <CloseIcon width={16} height={16} />
+          <CloseIcon width={14} height={14} />
         </button>
+
+        <span
+          key={cycle}
+          style={{
+            animationDuration: `${AUTO_DISMISS_MS}ms`,
+            animationPlayState: paused ? "paused" : "running",
+          }}
+          class="animate-progress absolute bottom-0 left-0 h-[3px] w-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-hover)]"
+        />
       </div>
     </div>
   );

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "preact/hooks";
 import { getVersion } from "@tauri-apps/api/app";
 import { api } from "../lib/api";
 import { useStore } from "../store";
+import { AccountSection } from "./AccountSection";
 import {
   BellIcon,
   BoltIcon,
@@ -140,6 +141,8 @@ export function SettingsView() {
       </header>
 
       <div class="mx-auto w-full max-w-2xl flex-1 overflow-y-auto px-8 pt-2 pb-8">
+        <AccountSection />
+
         {/* Startup */}
         <Section title="Startup">
           <Row

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -65,6 +65,7 @@ export function Sidebar() {
         <button
           onClick={toggleFocus}
           title="Focus timer"
+          data-focus-toggle
           class="mt-auto grid h-9 w-9 place-items-center rounded-lg text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
         >
           <TimerIcon width={18} height={18} />
@@ -132,6 +133,7 @@ export function Sidebar() {
       <div class="mt-auto flex flex-col gap-0.5 border-t border-[var(--color-border)] pt-3">
         <button
           onClick={toggleFocus}
+          data-focus-toggle
           class="flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-sm text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)]"
         >
           <TimerIcon width={18} height={18} />

--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -82,7 +82,7 @@ export function TaskDetail() {
     if (notes !== (task.notes ?? ""))
       patchTask({ id: task.id, notes: notes || null });
   };
-  const toggleLabel = (lid: number) => {
+  const toggleLabel = (lid: string) => {
     const has = task.labelIds.includes(lid);
     const next = has
       ? task.labelIds.filter((x) => x !== lid)

--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -26,19 +26,19 @@ export function TaskSection({
   reorderable: boolean;
 }) {
   const reorderTask = useStore((s) => s.reorderTask);
-  const [dragId, setDragId] = useState<number | null>(null);
-  const [over, setOver] = useState<{ id: number; edge: Edge } | null>(null);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [over, setOver] = useState<{ id: string; edge: Edge } | null>(null);
 
   // Live refs so the document-level pointer listeners always read fresh values
   // instead of the values captured when the drag started.
-  const rows = useRef(new Map<number, HTMLElement>());
+  const rows = useRef(new Map<string, HTMLElement>());
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
-  const dragIdRef = useRef<number | null>(null);
-  const overRef = useRef<{ id: number; edge: Edge } | null>(null);
+  const dragIdRef = useRef<string | null>(null);
+  const overRef = useRef<{ id: string; edge: Edge } | null>(null);
   const movedRef = useRef(false);
 
-  const setRow = (id: number) => (el: HTMLElement | null) => {
+  const setRow = (id: string) => (el: HTMLElement | null) => {
     if (el) rows.current.set(id, el);
     else rows.current.delete(id);
   };
@@ -52,7 +52,7 @@ export function TaskSection({
       setDragId(null);
       setOver(null);
     };
-    if (dId == null || !ov || dId === ov.id) return finish();
+    if (dId === null || !ov || dId === ov.id) return finish();
 
     // Position relative to the list with the dragged task removed.
     const rest = tasksRef.current.filter((t) => t.id !== dId);
@@ -74,7 +74,7 @@ export function TaskSection({
   };
 
   const startDrag =
-    (id: number) => (e: JSX.TargetedPointerEvent<HTMLElement>) => {
+    (id: string) => (e: JSX.TargetedPointerEvent<HTMLElement>) => {
       if (!reorderable || e.button !== 0) return;
       // Stop the row's onClick (task selection) from firing on release, and
       // suppress text selection while dragging.
@@ -92,7 +92,7 @@ export function TaskSection({
         // Find the insertion point by comparing the pointer against each other
         // row's midpoint. Falls through to "after the last row" when the
         // pointer is below every candidate.
-        let target: { id: number; edge: Edge } | null = null;
+        let target: { id: string; edge: Edge } | null = null;
         const others = tasksRef.current.filter(
           (t) => t.id !== dragIdRef.current,
         );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,18 +13,18 @@ export const api = {
   listTasks: () => invoke<Task[]>("list_tasks"),
   createTask: (task: NewTask) => invoke<Task>("create_task", { task }),
   updateTask: (patch: TaskPatch) => invoke<Task>("update_task", { patch }),
-  reorderTask: (id: number, orderIndex: number) =>
+  reorderTask: (id: string, orderIndex: number) =>
     invoke<Task>("reorder_task", { id, orderIndex }),
-  toggleTask: (id: number, done: boolean) =>
+  toggleTask: (id: string, done: boolean) =>
     invoke<Task>("toggle_task", { id, done }),
-  deleteTask: (id: number) => invoke<void>("delete_task", { id }),
+  deleteTask: (id: string) => invoke<void>("delete_task", { id }),
 
   listLabels: () => invoke<Label[]>("list_labels"),
   createLabel: (name: string, color: string) =>
     invoke<Label>("create_label", { name, color }),
-  updateLabel: (id: number, name: string, color: string) =>
+  updateLabel: (id: string, name: string, color: string) =>
     invoke<Label>("update_label", { id, name, color }),
-  deleteLabel: (id: number) => invoke<void>("delete_label", { id }),
+  deleteLabel: (id: string) => invoke<void>("delete_label", { id }),
 
   getSetting: (key: string) => invoke<string | null>("get_setting", { key }),
   setSetting: (key: string, value: string) =>
@@ -37,7 +37,7 @@ export const api = {
   sendTestNotification: () => invoke<string>("send_test_notification"),
 
   // Per-task stopwatch
-  startTimer: (id: number) => invoke<ActiveTimer | null>("start_timer", { id }),
+  startTimer: (id: string) => invoke<ActiveTimer | null>("start_timer", { id }),
   stopTimer: () => invoke<void>("stop_timer"),
   activeTimer: () => invoke<ActiveTimer | null>("active_timer"),
   focusHistory: (limit = 200) =>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,56 @@
+import { create } from "zustand";
+import type { Session } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+
+type AuthResult = { ok: true } | { ok: false; error: string };
+
+interface AuthState {
+  session: Session | null;
+  /** False until the initial session lookup resolves, so the UI can wait. */
+  ready: boolean;
+  email: string | null;
+
+  init: () => void;
+  signIn: (email: string, password: string) => Promise<AuthResult>;
+  signUp: (email: string, password: string) => Promise<AuthResult>;
+  signOut: () => Promise<void>;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  session: null,
+  ready: false,
+  email: null,
+
+  init: () => {
+    supabase.auth.getSession().then(({ data }) => {
+      set({
+        session: data.session,
+        email: data.session?.user.email ?? null,
+        ready: true,
+      });
+    });
+    supabase.auth.onAuthStateChange((_event, session) => {
+      set({ session, email: session?.user.email ?? null });
+    });
+  },
+
+  signIn: async (email, password) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: email.trim(),
+      password,
+    });
+    return error ? { ok: false, error: error.message } : { ok: true };
+  },
+
+  signUp: async (email, password) => {
+    const { error } = await supabase.auth.signUp({
+      email: email.trim(),
+      password,
+    });
+    return error ? { ok: false, error: error.message } : { ok: true };
+  },
+
+  signOut: async () => {
+    await supabase.auth.signOut();
+  },
+}));

--- a/src/lib/nlp.ts
+++ b/src/lib/nlp.ts
@@ -9,7 +9,7 @@ export interface ParsedQuickAdd {
   time: string | null; // HH:mm, only when a clock time was stated
   priority: number | null; // 1..4
   repeat: RepeatRule | null;
-  labelIds: number[];
+  labelIds: string[];
   labelNames: string[];
 }
 
@@ -50,7 +50,7 @@ export function parseQuickAdd(input: string, labels: Label[]): ParsedQuickAdd {
   let text = input;
   let priority: number | null = null;
   let repeat: RepeatRule | null = null;
-  const labelIds: number[] = [];
+  const labelIds: string[] = [];
   const labelNames: string[] = [];
 
   // Priority first, so chrono never sees `p1` etc.

--- a/src/lib/secureStorage.ts
+++ b/src/lib/secureStorage.ts
@@ -1,0 +1,41 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Supabase auth storage backed by the OS keychain (via Tauri `secret_*`
+ * commands), so session tokens don't live in the webview's localStorage.
+ *
+ * If the keychain isn't reachable — no secret service on the box, or we're
+ * running outside Tauri (e.g. a browser preview) — it transparently falls back
+ * to localStorage so sign-in still works. The first failure flips the switch so
+ * we don't retry the bridge on every call.
+ */
+let keychainOk = true;
+
+async function viaKeychain<T>(fn: () => Promise<T>, fallback: () => T): Promise<T> {
+  if (keychainOk) {
+    try {
+      return await fn();
+    } catch {
+      keychainOk = false;
+    }
+  }
+  return fallback();
+}
+
+export const secureStorage = {
+  getItem: (key: string) =>
+    viaKeychain(
+      () => invoke<string | null>("secret_get", { key }),
+      () => localStorage.getItem(key),
+    ),
+  setItem: (key: string, value: string) =>
+    viaKeychain(
+      () => invoke<void>("secret_set", { key, value }),
+      () => localStorage.setItem(key, value),
+    ),
+  removeItem: (key: string) =>
+    viaKeychain(
+      () => invoke<void>("secret_delete", { key }),
+      () => localStorage.removeItem(key),
+    ),
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+import { secureStorage } from "./secureStorage";
+
+const url =
+  import.meta.env.VITE_SUPABASE_URL ?? "http://127.0.0.1:54321";
+const anonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ??
+  "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH";
+
+export const supabase = createClient(url, anonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: false,
+    storage: secureStorage,
+  },
+});

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,150 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import { supabase } from "./supabase";
+import { useAuth } from "./auth";
+import { useStore } from "../store";
+
+interface Bundle {
+  tasks: unknown[];
+  labels: unknown[];
+  task_labels: unknown[];
+  sessions: unknown[];
+}
+
+export type SyncStatus = "idle" | "syncing" | "error" | "offline";
+
+interface SyncState {
+  status: SyncStatus;
+  lastSyncedAt: string | null;
+  error: string | null;
+  syncNow: () => Promise<void>;
+}
+
+export const useSync = create<SyncState>((set, get) => ({
+  status: "idle",
+  lastSyncedAt: null,
+  error: null,
+  syncNow: async () => {
+    if (get().status === "syncing") return;
+    if (!useAuth.getState().session) return;
+
+    set({ status: "syncing", error: null });
+    try {
+      const since = await invoke<string>("sync_get_watermark");
+      const startedAt = new Date().toISOString();
+
+      // Pull remote changes, then merge them locally (last-write-wins).
+      const remote = await pull(since);
+      await invoke("sync_apply", { remote });
+
+      // Push everything changed locally since the last round.
+      const local = await invoke<Bundle>("sync_changes_since", { since });
+      await push(local);
+
+      // Advance the watermark to the moment the round began, so anything
+      // written mid-sync is caught next time rather than skipped.
+      await invoke("sync_set_watermark", { value: startedAt });
+
+      // Reflect merged remote data in the UI without a loading flash.
+      applying = true;
+      try {
+        await useStore.getState().load();
+        await useStore.getState().loadTimers();
+      } finally {
+        applying = false;
+      }
+
+      set({ status: "idle", lastSyncedAt: startedAt, error: null });
+
+      // Reclaim space from tombstones old enough to have propagated everywhere.
+      invoke("sync_purge_tombstones", { days: 30 }).catch(() => {});
+    } catch (e) {
+      const offline = e instanceof TypeError || /fetch|network/i.test(String(e));
+      set({ status: offline ? "offline" : "error", error: String(e) });
+    }
+  },
+}));
+
+async function pull(since: string): Promise<Bundle> {
+  const fetchTable = async (table: string) => {
+    const { data, error } = await supabase
+      .from(table)
+      .select("*")
+      .gt("updated_at", since);
+    if (error) throw new Error(error.message);
+    return data ?? [];
+  };
+  // Fetch order doesn't matter; sync_apply merges in FK-safe order.
+  return {
+    labels: await fetchTable("labels"),
+    tasks: await fetchTable("tasks"),
+    task_labels: await fetchTable("task_labels"),
+    sessions: await fetchTable("time_sessions"),
+  };
+}
+
+async function push(local: Bundle): Promise<void> {
+  const upsert = async (table: string, rows: unknown[], onConflict?: string) => {
+    if (!rows.length) return;
+    const query = onConflict
+      ? supabase.from(table).upsert(rows, { onConflict })
+      : supabase.from(table).upsert(rows);
+    const { error } = await query;
+    if (error) throw new Error(error.message);
+  };
+  // Parents before children, so a foreign key never lands before its target.
+  await upsert("labels", local.labels);
+  await upsert("tasks", local.tasks);
+  await upsert("task_labels", local.task_labels, "task_id,label_id");
+  await upsert("time_sessions", local.sessions);
+}
+
+// --- Triggers ---------------------------------------------------------------
+
+/** True while sync is applying pulled data, so the store subscription below
+ *  doesn't treat sync's own refresh as a fresh local edit. */
+let applying = false;
+let debounce: ReturnType<typeof setTimeout> | undefined;
+let interval: ReturnType<typeof setInterval> | undefined;
+
+/** Debounced push after a local edit. */
+function scheduleSync() {
+  if (applying || !useAuth.getState().session) return;
+  clearTimeout(debounce);
+  debounce = setTimeout(() => void useSync.getState().syncNow(), 1500);
+}
+
+/**
+ * Wire up sync: run on sign-in, poll periodically while signed in, and push
+ * shortly after any local task/label change. Safe to call once at startup; it
+ * reacts to auth state on its own. Assumes one account per install — switching
+ * accounts on the same device is not handled here.
+ */
+export function initSync() {
+  let lastUserId: string | null = useAuth.getState().session?.user.id ?? null;
+
+  useAuth.subscribe((s) => {
+    const userId = s.session?.user.id ?? null;
+    if (userId === lastUserId) return;
+    lastUserId = userId;
+
+    clearInterval(interval);
+    if (userId) {
+      void useSync.getState().syncNow();
+      interval = setInterval(() => void useSync.getState().syncNow(), 30_000);
+    } else {
+      useSync.setState({ status: "idle", lastSyncedAt: null, error: null });
+    }
+  });
+
+  // A change to the task or label lists means a local edit worth pushing.
+  useStore.subscribe((state, prev) => {
+    if (state.tasks !== prev.tasks || state.labels !== prev.labels) scheduleSync();
+  });
+
+  // If a session was already restored at launch, kick off the first round.
+  if (useAuth.getState().session) {
+    void useSync.getState().syncNow();
+    interval = setInterval(() => void useSync.getState().syncNow(), 30_000);
+  }
+}

--- a/src/notification.tsx
+++ b/src/notification.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { NotificationPopup } from "./components/NotificationPopup";
+import { ContextMenu } from "./components/ContextMenu";
 import { applyTheme, initialTheme } from "./lib/theme";
 import "./styles/global.css";
 
@@ -8,4 +9,10 @@ import "./styles/global.css";
 applyTheme(initialTheme());
 document.body.style.background = "transparent";
 
-render(<NotificationPopup />, document.getElementById("root")!);
+render(
+  <>
+    <NotificationPopup />
+    <ContextMenu />
+  </>,
+  document.getElementById("root")!,
+);

--- a/src/quickadd.tsx
+++ b/src/quickadd.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { QuickCapture } from "./components/QuickCapture";
+import { ContextMenu } from "./components/ContextMenu";
 import { applyTheme, initialTheme } from "./lib/theme";
 import "./styles/global.css";
 
@@ -8,4 +9,10 @@ import "./styles/global.css";
 applyTheme(initialTheme());
 document.body.style.background = "transparent";
 
-render(<QuickCapture />, document.getElementById("root")!);
+render(
+  <>
+    <QuickCapture />
+    <ContextMenu />
+  </>,
+  document.getElementById("root")!,
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,14 +26,14 @@ interface State {
   tasks: Task[];
   labels: Label[];
   view: ViewId;
-  selectedId: number | null;
+  selectedId: string | null;
   loading: boolean;
   reminders: ActiveReminder[];
   theme: Theme;
   confirm: ConfirmOptions | null;
   sidebarCollapsed: boolean;
   searchQuery: string;
-  filterLabelIds: number[];
+  filterLabelIds: string[];
   filterPriorities: number[];
 
   activeTimer: ActiveTimer | null;
@@ -48,9 +48,9 @@ interface State {
 
   load: () => Promise<void>;
   setView: (view: ViewId) => void;
-  select: (id: number | null) => void;
+  select: (id: string | null) => void;
   setSearchQuery: (q: string) => void;
-  toggleFilterLabel: (id: number) => void;
+  toggleFilterLabel: (id: string) => void;
   toggleFilterPriority: (p: number) => void;
   clearFilters: () => void;
   toggleTheme: () => void;
@@ -58,27 +58,27 @@ interface State {
   toggleShortcuts: (open?: boolean) => void;
   toggleCelebrate: () => void;
   pushReminder: (r: ActiveReminder) => void;
-  dismissReminder: (id: number) => void;
+  dismissReminder: (id: string) => void;
   requestConfirm: (opts: ConfirmOptions) => void;
   closeConfirm: () => void;
 
   addTask: (input: NewTask) => Promise<void>;
   patchTask: (patch: TaskPatch) => Promise<void>;
-  reorderTask: (id: number, orderIndex: number) => Promise<void>;
-  toggleTask: (id: number, done: boolean) => Promise<void>;
-  snoozeTask: (id: number, minutes: number) => Promise<void>;
+  reorderTask: (id: string, orderIndex: number) => Promise<void>;
+  toggleTask: (id: string, done: boolean) => Promise<void>;
+  snoozeTask: (id: string, minutes: number) => Promise<void>;
   rescheduleOverdue: () => Promise<void>;
-  removeTask: (id: number) => Promise<void>;
+  removeTask: (id: string) => Promise<void>;
 
   addLabel: (name: string, color: string) => Promise<Label>;
-  editLabel: (id: number, name: string, color: string) => Promise<void>;
-  removeLabel: (id: number) => Promise<void>;
+  editLabel: (id: string, name: string, color: string) => Promise<void>;
+  removeLabel: (id: string) => Promise<void>;
 
   loadTimers: () => Promise<void>;
   onTimersChanged: () => Promise<void>;
   toggleFocus: () => void;
   refreshPomodoro: () => Promise<void>;
-  startTaskTimer: (id: number) => Promise<void>;
+  startTaskTimer: (id: string) => Promise<void>;
   stopTaskTimer: () => Promise<void>;
   pomodoroStart: () => Promise<void>;
   pomodoroPause: () => Promise<void>;
@@ -360,7 +360,7 @@ function sortTasks(tasks: Task[]): Task[] {
 export function applySearchAndFilters(
   tasks: Task[],
   searchQuery: string,
-  filterLabelIds: number[],
+  filterLabelIds: string[],
   filterPriorities: number[],
 ): Task[] {
   const query = searchQuery.trim().toLowerCase();
@@ -425,7 +425,7 @@ export function navCount(tasks: Task[], view: ViewId): number {
 }
 
 /** Task ids in on-screen order for the active view — drives keyboard nav. */
-export function visibleTaskIds(tasks: Task[], view: ViewId): number[] {
+export function visibleTaskIds(tasks: Task[], view: ViewId): string[] {
   const { searchQuery, filterLabelIds, filterPriorities } = useStore.getState();
   const inView = applySearchAndFilters(
     tasksForView(tasks, view),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -129,6 +129,21 @@ body {
   animation: slide-left 0.2s ease-out;
 }
 
+/* Depleting auto-dismiss bar on the notification popup. Duration is set inline
+   and play-state is paused while the card is hovered. */
+@keyframes progress-shrink {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+.animate-progress {
+  transform-origin: left;
+  animation: progress-shrink linear forwards;
+}
+
 /* A quick confetti burst on task completion. Each piece is translated to its
    own (--dx,--dy) offset and spun by (--rot), then fades. Disabled wholesale
    by the reduced-motion block below. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export interface Label {
-  id: number;
+  id: string; // UUID
   name: string;
   color: string;
 }
@@ -15,7 +15,7 @@ export interface Subtask {
 }
 
 export interface Task {
-  id: number;
+  id: string; // UUID
   title: string;
   notes: string | null;
   dueDate: string | null; // YYYY-MM-DD
@@ -28,21 +28,21 @@ export interface Task {
   pinned: boolean;
   repeat: RepeatRule | null;
   trackedSeconds: number;
-  labelIds: number[];
+  labelIds: string[];
   subtasks: Subtask[];
 }
 
 /** The currently running per-task stopwatch. */
 export interface ActiveTimer {
-  taskId: number;
+  taskId: string;
   title: string;
   startAt: string; // ISO
 }
 
 /** A completed focus session, for the history view. */
 export interface SessionLog {
-  id: number;
-  taskId: number;
+  id: string;
+  taskId: string;
   title: string;
   startAt: string;
   endAt: string;
@@ -71,18 +71,18 @@ export interface NewTask {
   dueDate?: string | null;
   remindAt?: string | null;
   priority?: number;
-  labelIds?: number[];
+  labelIds?: string[];
   repeat?: RepeatRule | null;
 }
 
 export interface TaskPatch {
-  id: number;
+  id: string;
   title?: string;
   notes?: string | null;
   dueDate?: string | null;
   remindAt?: string | null;
   priority?: number;
-  labelIds?: number[];
+  labelIds?: string[];
   pinned?: boolean;
   repeat?: RepeatRule | null;
   subtasks?: Subtask[];
@@ -90,7 +90,7 @@ export interface TaskPatch {
 
 /** A reminder that has fired, shown as an in-app toast. */
 export interface ActiveReminder {
-  id: number;
+  id: string;
   title: string;
 }
 
@@ -104,4 +104,4 @@ export type ViewId =
   | { kind: "labels" }
   | { kind: "settings" }
   | { kind: "focus" }
-  | { kind: "label"; labelId: number };
+  | { kind: "label"; labelId: string };

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "todofy"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./supabase/templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./schemas"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260826120000_sync_schema.sql
+++ b/supabase/migrations/20260826120000_sync_schema.sql
@@ -1,0 +1,92 @@
+-- Cloud mirror of the local SQLite tables for account sync.
+-- Ids are the same UUIDs the client generates on-device, so a row round-trips
+-- unchanged. Every table is per-user (`user_id`), carries `updated_at` for
+-- last-write-wins ordering, and `deleted_at` as a soft-delete tombstone.
+
+create table if not exists public.labels (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  name       text not null,
+  color      text not null default '#6c7cff',
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create table if not exists public.tasks (
+  id           uuid primary key default gen_random_uuid(),
+  user_id      uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  title        text not null,
+  notes        text,
+  due_date     date,
+  remind_at    timestamptz,
+  status       text not null default 'active',
+  priority     smallint not null default 4,
+  created_at   timestamptz not null default now(),
+  completed_at timestamptz,
+  order_index  double precision not null default 0,
+  pinned       boolean not null default false,
+  repeat       text,
+  subtasks     jsonb not null default '[]'::jsonb,
+  updated_at   timestamptz not null default now(),
+  deleted_at   timestamptz
+);
+
+create table if not exists public.task_labels (
+  user_id    uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  task_id    uuid not null references public.tasks (id) on delete cascade,
+  label_id   uuid not null references public.labels (id) on delete cascade,
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  primary key (task_id, label_id)
+);
+
+create table if not exists public.time_sessions (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  task_id    uuid not null references public.tasks (id) on delete cascade,
+  start_at   timestamptz not null,
+  end_at     timestamptz,
+  seconds    integer,
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+-- Pull queries scan by (user_id, updated_at); the FK index speeds session joins.
+create index if not exists labels_user_updated_idx on public.labels (user_id, updated_at);
+create index if not exists tasks_user_updated_idx on public.tasks (user_id, updated_at);
+create index if not exists task_labels_user_updated_idx on public.task_labels (user_id, updated_at);
+create index if not exists time_sessions_user_updated_idx on public.time_sessions (user_id, updated_at);
+create index if not exists time_sessions_task_idx on public.time_sessions (task_id);
+
+-- Row-level security: a user can only ever see or touch their own rows.
+alter table public.labels enable row level security;
+alter table public.tasks enable row level security;
+alter table public.task_labels enable row level security;
+alter table public.time_sessions enable row level security;
+
+create policy "own labels" on public.labels
+  for all to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "own tasks" on public.tasks
+  for all to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "own task_labels" on public.task_labels
+  for all to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "own time_sessions" on public.time_sessions
+  for all to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- RLS decides which rows; these grant the signed-in role table-level DML at all.
+-- No grants to `anon` — sync always runs authenticated.
+grant select, insert, update, delete on public.labels to authenticated;
+grant select, insert, update, delete on public.tasks to authenticated;
+grant select, insert, update, delete on public.task_labels to authenticated;
+grant select, insert, update, delete on public.time_sessions to authenticated;


### PR DESCRIPTION
Ships **v1.7.0**. The headline is **optional account sync**; everything else is UI polish and fixes. The app remains fully local-first and works offline with no account.

## ✨ Account sync (opt-in)
Sign in with an email + password (Settings → Account) to sync tasks, labels, and focus history across devices, backed by Supabase with row-level security.

- **UUID primary keys** for syncable rows — records created offline on separate devices merge without id collisions (one-time in-place SQLite migration; covered by tests)
- **Soft-delete tombstones + `updated_at`** on `tasks`, `labels`, `task_labels`, `time_sessions` so edits and deletions propagate
- **Cloud schema + RLS** in `supabase/migrations/` — each row is scoped to its owner; validated end-to-end (tenant isolation, forge-prevention, incremental pull)
- **Auth** in a polished in-app modal, with a live sync-status indicator (synced / syncing / offline / failed) and a manual **Sync now** button
- **Sessions in the OS secret store** (libsecret / Keychain / Credential Manager), falling back to localStorage where no keychain exists
- **Sync engine** (frontend-orchestrated): pull → merge (last-write-wins by `updated_at`, compared as instants) → push; runs on sign-in, on a poll, and debounced after edits. Old tombstones are purged after each round

## 🎨 UI / polish
- **Redesigned notification popup** — ringed icon, cleaner card, and a slim auto-dismiss progress bar that pauses on hover
- **Custom right-click menu** replacing the webview's browser menu (Back / Forward / Reload / **Inspect Element**): context-aware Cut / Copy / Paste / Select all with shortcut hints, plus New task / Settings / theme actions. Present in all three windows

## 🐛 Fixes
- The notification popup can no longer get **stuck as an invisible, click-blocking window** in a screen corner (backend safety auto-hide + pull-pending-on-mount)
- Fixed a **focus-timer hang**: the scheduler held the SQLite lock across a blocking notification call, which could freeze the whole app; notifications are now sent after the lock is released

## ✅ Testing
- 6 Rust unit tests (UUID migration, sync merge/LWW, tombstone GC) — all pass
- `tsc` + production build clean
- Sync push/pull/RLS validated against a local Supabase stack via PostgREST with the exact payload shapes; auth flow verified live (sign up/in/out, reload restore); custom menu + popup verified in preview

## ⚠️ Before this is user-facing
- The client points at a **local Supabase stack** (`.env` + dev fallbacks). Sync needs a real cloud project first: set `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` and apply the migration (`supabase db push` or the dashboard). No code change needed.
- **One account per install** — switching accounts on the same device isn't handled yet. Not collaboration-safe (single user's own devices, last-write-wins).