### PR TITLE
v1.7.3 — fix task_labels FK violation on sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v1.7.2 — 2026-08-27
+## v1.7.3 — 2026-08-28
+
+### Fixed
+
+- Account sync no longer fails with `insert or update on table "task_labels" violates foreign key constraint "task_labels_label_id_fkey"`. A label whose `updated_at` sat at or below the sync watermark (already synced, or stamped there when an older database was migrated) was skipped on push, yet assigning it to a task pushed the association — which then referenced a label the server had never seen. A changed association now carries its parent task and label along in the same push, so a child never lands ahead of its parent
+
+
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ Grab a package from the [Releases](../../releases) page, or build it yourself (s
 **AppImage** — portable, runs on any distro:
 
 ```bash
-chmod +x todofy_1.7.2_amd64.AppImage
-./todofy_1.7.2_amd64.AppImage
+chmod +x todofy_1.7.3_amd64.AppImage
+./todofy_1.7.3_amd64.AppImage
 ```
 
 **Debian / Ubuntu:**
 
 ```bash
-sudo dpkg -i todofy_1.7.2_amd64.deb
+sudo dpkg -i todofy_1.7.3_amd64.deb
 ```
 
 **Fedora / RHEL / openSUSE:**
 
 ```bash
-sudo rpm -i todofy-1.7.2-1.x86_64.rpm
+sudo rpm -i todofy-1.7.3-1.x86_64.rpm
 ```
 
 **macOS** — open the `.dmg` and drag todofy into Applications. It's not
@@ -109,15 +109,15 @@ notarized yet, so on first launch right‑click the app and choose **Open** to
 get past Gatekeeper:
 
 ```
-todofy_1.7.2_x64.dmg      # Intel
-todofy_1.7.2_aarch64.dmg  # Apple Silicon
+todofy_1.7.3_x64.dmg      # Intel
+todofy_1.7.3_aarch64.dmg  # Apple Silicon
 ```
 
 **Windows** — run the installer:
 
 ```
-todofy_1.7.2_x64-setup.exe   # NSIS installer
-todofy_1.7.2_x64_en-US.msi   # or the MSI
+todofy_1.7.3_x64-setup.exe   # NSIS installer
+todofy_1.7.3_x64_en-US.msi   # or the MSI
 ```
 
 > Your tasks live in the app's data directory — `~/.local/share/com.unifybrowse.todofy/`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todofy",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4320,7 +4320,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todofy"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todofy"
-version = "1.7.2"
+version = "1.7.3"
 description = "A modern to-do app for Linux"
 authors = ["Salar Zeidanlou"]
 edition = "2021"

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -174,15 +174,19 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+/// Baseline `updated_at` for pre-sync rows: one tick past the epoch, so it's the
+/// oldest possible yet still clears the epoch-seeded sync watermark.
+const PRE_SYNC_BASELINE: &str = "'1970-01-01T00:00:01+00:00'";
+
 /// Add `updated_at` / `deleted_at` to a syncable table, backfilling
 /// `updated_at` from an existing timestamp column so pre-sync rows get a sane
 /// baseline. Idempotent via the column guards.
 fn add_sync_columns(conn: &Connection) -> rusqlite::Result<()> {
     for (table, backfill) in [
         ("tasks", "created_at"),
-        ("labels", "'1970-01-01T00:00:00+00:00'"),
+        ("labels", PRE_SYNC_BASELINE),
         ("time_sessions", "start_at"),
-        ("task_labels", "'1970-01-01T00:00:00+00:00'"),
+        ("task_labels", PRE_SYNC_BASELINE),
     ] {
         if !column_exists(conn, table, "updated_at") {
             conn.execute(

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -7,9 +7,10 @@
 use crate::db::Db;
 use crate::settings;
 use chrono::DateTime;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 use tauri::State;
 
 const WATERMARK_KEY: &str = "sync_last_synced_at";
@@ -185,12 +186,89 @@ fn collect_changes(conn: &Connection, since: &str) -> rusqlite::Result<SyncBundl
         }
     }
 
+    // Include any referenced parent missing from the bundle, so a changed
+    // child never pushes ahead of a parent still below the watermark.
+    let have_task: HashSet<&str> = tasks.iter().map(|t| t.id.as_str()).collect();
+    let have_label: HashSet<&str> = labels.iter().map(|l| l.id.as_str()).collect();
+    let mut need_tasks: HashSet<String> = HashSet::new();
+    let mut need_labels: HashSet<String> = HashSet::new();
+    for tl in &task_labels {
+        if !have_task.contains(tl.task_id.as_str()) {
+            need_tasks.insert(tl.task_id.clone());
+        }
+        if !have_label.contains(tl.label_id.as_str()) {
+            need_labels.insert(tl.label_id.clone());
+        }
+    }
+    for s in &sessions {
+        if !have_task.contains(s.task_id.as_str()) {
+            need_tasks.insert(s.task_id.clone());
+        }
+    }
+    drop((have_task, have_label));
+    for id in need_labels {
+        if let Some(row) = fetch_label(conn, &id)? {
+            labels.push(row);
+        }
+    }
+    for id in need_tasks {
+        if let Some(row) = fetch_task(conn, &id)? {
+            tasks.push(row);
+        }
+    }
+
     Ok(SyncBundle {
         tasks,
         labels,
         task_labels,
         sessions,
     })
+}
+
+fn fetch_label(conn: &Connection, id: &str) -> rusqlite::Result<Option<SyncLabel>> {
+    conn.query_row(
+        "SELECT id, name, color, updated_at, deleted_at FROM labels WHERE id = ?1",
+        [id],
+        |r| {
+            Ok(SyncLabel {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                color: r.get(2)?,
+                updated_at: r.get(3)?,
+                deleted_at: r.get(4)?,
+            })
+        },
+    )
+    .optional()
+}
+
+fn fetch_task(conn: &Connection, id: &str) -> rusqlite::Result<Option<SyncTask>> {
+    conn.query_row(
+        "SELECT id, title, notes, due_date, remind_at, status, priority, created_at,
+                completed_at, order_index, pinned, repeat, subtasks, updated_at, deleted_at
+         FROM tasks WHERE id = ?1",
+        [id],
+        |r| {
+            Ok(SyncTask {
+                id: r.get(0)?,
+                title: r.get(1)?,
+                notes: r.get(2)?,
+                due_date: r.get(3)?,
+                remind_at: r.get(4)?,
+                status: r.get(5)?,
+                priority: r.get(6)?,
+                created_at: r.get(7)?,
+                completed_at: r.get(8)?,
+                order_index: r.get(9)?,
+                pinned: r.get::<_, i64>(10)? != 0,
+                repeat: r.get(11)?,
+                subtasks: subtasks_value(r.get(12)?),
+                updated_at: r.get(13)?,
+                deleted_at: r.get(14)?,
+            })
+        },
+    )
+    .optional()
 }
 
 // ------------------------------------------------------------------- pull side
@@ -458,6 +536,36 @@ mod tests {
         assert_eq!(bundle.labels[0].id, "new");
         // The tombstone travels so the deletion can propagate.
         assert!(bundle.labels[0].deleted_at.is_some());
+    }
+
+    #[test]
+    fn changed_association_drags_its_parents_along() {
+        let conn = setup();
+        // A label and task synced long ago (updated_at below the watermark).
+        conn.execute(
+            "INSERT INTO labels (id, name, color, updated_at) VALUES ('l1', 'home', '#111', ?1)",
+            ["2020-01-01T00:00:00+00:00"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tasks (id, title, created_at, updated_at) VALUES ('t1', 'x', ?1, ?1)",
+            ["2020-01-01T00:00:00+00:00"],
+        )
+        .unwrap();
+        // A fresh association above the watermark.
+        conn.execute(
+            "INSERT INTO task_labels (task_id, label_id, updated_at) VALUES ('t1', 'l1', ?1)",
+            ["2026-06-01T00:00:00+00:00"],
+        )
+        .unwrap();
+
+        let bundle = collect_changes(&conn, "2026-01-01T00:00:00+00:00").unwrap();
+        // The association is newer than the watermark, so it must ship — and so
+        // must its parents, even though they weren't touched, or the push would
+        // trip the foreign key.
+        assert_eq!(bundle.task_labels.len(), 1);
+        assert_eq!(bundle.labels.iter().map(|l| l.id.as_str()).collect::<Vec<_>>(), ["l1"]);
+        assert_eq!(bundle.tasks.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(), ["t1"]);
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "todofy",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "identifier": "com.unifybrowse.todofy",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Fixes account sync failing with:

> Error: insert or update on table "task_labels" violates foreign key constraint "task_labels_label_id_fkey"

### Root cause

Push sends only rows with `updated_at > watermark`. A label whose `updated_at` sat at or below the watermark — either already synced, or stamped at the epoch when an older database was migrated — was never collected. Assigning that label to a task stamps the **`task_labels`** row with `now()`, so the association *was* pushed, referencing a label the server had never seen → FK violation. (Confirmed against production: tasks synced, labels count was 0.)

### Fix

- `collect_changes` now pulls a changed child's parent `task`/`label` into the same bundle even if the parent is below the watermark, so push order (parents → children) always holds. Re-sending a parent the server already has is a harmless upsert.
- Pre-sync rows are stamped one tick past the epoch (`PRE_SYNC_BASELINE`) so they clear the initial watermark.

### Tests

- New `changed_association_drags_its_parents_along`; all lib tests pass, clippy clean.

### Also

- Version bumped 1.7.2 → 1.7.3 (package.json, Cargo.toml, tauri.conf.json), CHANGELOG + README updated.